### PR TITLE
Add compatibility with OSX 10.10 Yosemite

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -197,7 +197,20 @@ def original_dst(sock):
         return (ip, port)
     except socket.error, e:
         if e.args[0] == errno.ENOPROTOOPT:
-            return sock.getsockname()
+            peer = sock.getpeername()
+
+            output = ssubprocess.Popen(["sudo", "-n", "/sbin/pfctl", "-s", "state"],
+                stdout=ssubprocess.PIPE,
+                stderr=ssubprocess.PIPE).communicate()[0]
+
+            spec = "%s:%s" % (peer[0], peer[1])
+            for line in output.split("\n"):
+                if "ESTABLISHED:ESTABLISHED" in line and spec in line:
+                    match = line.split()
+                    if len(match) > 4:
+                        submatch = match[4].split(":")
+                        if len(submatch) == 2:
+                            return submatch[0], int(submatch[1])
         raise
 
 

--- a/src/firewall.py
+++ b/src/firewall.py
@@ -145,18 +145,18 @@ def pfctl(*arg):
         stderr = ssubprocess.PIPE)
     return p.wait()
 
-def do_pf(port, dnsport, subnets):
+def do_pf(port, dnsport, family, subnets, udp):
     exclude_set = []
     redirect_set = []
     ns_set = []
 
     if dnsport:
         nslist = resolvconf_nameservers()
-        for ip in nslist:
+        for f, ip in nslist:
             ns_set.append(ip)
 
     if subnets:
-        for swidth,sexclude,snet in sorted(subnets, reverse=True):
+        for f, swidth, sexclude, snet in sorted(subnets, reverse=True):
             if sexclude:
                 exclude_set.append("%s/%s" % (snet,swidth))
             else:

--- a/src/firewall.py
+++ b/src/firewall.py
@@ -594,7 +594,7 @@ def main(port_v6, port_v4, dnsport_v6, dnsport_v4, method, udp, syslog):
         elif program_exists('pfctl'):
             method = "pf"
         else:
-            raise Fatal("can't find either ipfw or iptables; check your PATH")
+            raise Fatal("can't find either ipfw, pf, or iptables; check your PATH")
 
     if method == "nat":
         do_it = do_iptables_nat

--- a/src/firewall.py
+++ b/src/firewall.py
@@ -137,6 +137,56 @@ def do_iptables_nat(port, dnsport, family, subnets, udp):
                     '--dport', '53',
                     '--to-ports', str(dnsport))
 
+def pfctl(*arg):
+    argv = ['sudo', 'pfctl']
+    argv.extend(arg)
+    p = ssubprocess.Popen(argv,
+        stdout = ssubprocess.PIPE,
+        stderr = ssubprocess.PIPE)
+    return p.wait()
+
+def do_pf(port, dnsport, subnets):
+    exclude_set = []
+    redirect_set = []
+    ns_set = []
+
+    if dnsport:
+        nslist = resolvconf_nameservers()
+        for ip in nslist:
+            ns_set.append(ip)
+
+    if subnets:
+        for swidth,sexclude,snet in sorted(subnets, reverse=True):
+            if sexclude:
+                exclude_set.append("%s/%s" % (snet,swidth))
+            else:
+                redirect_set.append("%s/%s" % (snet,swidth))
+
+        ruleset = [
+            'packets = "proto tcp to {%s}"' % ','.join(redirect_set),
+            'rdr pass on lo0 $packets -> 127.0.0.1 port %s' % port,
+            'pass out route-to lo0 inet $packets keep state'
+            ]
+
+        if len(ns_set) > 0:
+            ns_ruleset = [
+                    'dnspackets = "proto udp to {%s} port 53"' % ','.join(ns_set),
+                    'rdr pass on lo0 $dnspackets -> 127.0.0.1 port %s' % port,
+                    'pass out route-to lo0 inet $dnspackets keep state'
+                ]
+            ruleset = list(sum(zip(ruleset, ns_ruleset), ()))
+
+        if len(exclude_set) > 0:
+            ruleset.append('pass out quick proto tcp to {%s}' % ','.join(exclude_set))
+
+        f = open('/etc/sshuttle.pf.conf', 'w+')
+        f.write('\n'.join(ruleset) + '\n')
+        f.close()
+
+        pfctl('-f', '/etc/sshuttle.pf.conf', '-E')
+    else:
+        pfctl('-d')
+        pfctl('-F', 'all')
 
 def do_iptables_tproxy(port, dnsport, family, subnets, udp):
     if family not in [socket.AF_INET, socket.AF_INET6]:
@@ -541,6 +591,8 @@ def main(port_v6, port_v4, dnsport_v6, dnsport_v4, method, udp, syslog):
             method = "ipfw"
         elif program_exists('iptables'):
             method = "nat"
+        elif program_exists('pfctl'):
+            method = "pf"
         else:
             raise Fatal("can't find either ipfw or iptables; check your PATH")
 
@@ -550,6 +602,8 @@ def main(port_v6, port_v4, dnsport_v6, dnsport_v4, method, udp, syslog):
         do_it = do_iptables_tproxy
     elif method == "ipfw":
         do_it = do_ipfw
+    elif method == "pf":
+        do_it = do_pf
     else:
         raise Exception('Unknown method "%s"' % method)
 


### PR DESCRIPTION
User @jagheterfredrik forked [apenwarr/sshuttle][1] into
[jagheterfredrik/sshuttle][2] and added support for OSX 10.10 Yosemite.
I forked [sshuttle/sshuttle][3] and cherry-picked those commits into
master. After which, there were still some compatibility issues with
[sshuttle/sshuttle][3] to be resolved as [apenwarr/sshuttle][1] and
[sshuttle/sshuttle][3] are divergent. This commit wraps up those changes.

In addition, it's worth noting that the current [homebrew][5] (as of this
commit) [formula][4] for sshuttle points to @apenwarr's fork. Once this
10.10 work is completed, the [formula][4] should be updated to point to
[sshuttle/sshuttle][3].

- [x] Cherry pick jagheterfredrik/sshuttle@5fbc3f7 & resolve conflicts.
- [x] Cherry pick jagheterfredrik/sshuttle@4c3b674 & resolve conflicts.
- [x] Alter src/firewall.py based on new variables passed into `do_`
      functions.
- [x] Alter src/firewall.py based on new `method = 'pf'` way of
      determining which firewall tool to use.

[1]: https://github.com/apenwarr/sshuttle "apenwarr's fork of sshuttle"
[2]: https://github.com/jagheterfredrik/sshuttle "jagheterfredrik fork of apenwarr/sshuttle"
[3]: https://github.com/sshuttle/sshuttle "This repo"
[4]: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/sshuttle.rb "Homebrew formula for sshuttle"
[5]: https://github.com/Homebrew/homebrew "mxcl's Homebrew"
