### PR TITLE
Fix the most blatant issues of the generated .deb

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ Required Software
 
  - You need PyXAPI, available here:
    http://www.pps.univ-paris-diderot.fr/~ylg/PyXAPI/
- - You also need autossh, available in various package management systems
  - Python 2.x, both locally and the remote system
+
+
+Additional Suggested Software
+-----------------------------
+
+ - You may want to need autossh, available in various package management
+   systems
 
 
 sshuttle: where transparent proxy meets VPN meets ssh

--- a/packaging/control
+++ b/packaging/control
@@ -2,7 +2,8 @@ Package: sshuttle
 Version: 0+git
 Architecture: all
 Maintainer: Jim Wyllie <jwyllie83@gmail.com>
-Depends: autossh, iptables, python (>= 2.6)
+Depends: iptables, python (>= 2.6)
+Suggests: autossh
 Section: net
 Priority: optional
 Homepage: http://github.com/sshuttle/sshuttle

--- a/packaging/control
+++ b/packaging/control
@@ -6,9 +6,10 @@ Depends: autossh, python (>= 2.6)
 Section: utils
 Priority: optional
 Homepage: http://github.com/sshuttle/sshuttle
-Description: "Full-featured" VPN over an SSH tunnel, allowing full remote
- access somewhere where all you have is an SSH connection.  It works well if
- you generally find yourself in the following situation:
+Description: "Full-featured" VPN over an SSH tunnel
+ It allows full remote access somewhere where all you have is an SSH
+ connection.  It works well if you generally find yourself in the
+ following situation:
  .
  - Your client machine (or router) is Linux, FreeBSD, or MacOS.
  - You have access to a remote network via ssh.

--- a/packaging/control
+++ b/packaging/control
@@ -2,7 +2,7 @@ Package: sshuttle
 Version: 0+git
 Architecture: all
 Maintainer: Jim Wyllie <jwyllie83@gmail.com>
-Depends: autossh, python (>= 2.6)
+Depends: autossh, iptables, python (>= 2.6)
 Section: utils
 Priority: optional
 Homepage: http://github.com/sshuttle/sshuttle

--- a/packaging/control
+++ b/packaging/control
@@ -23,5 +23,5 @@ Description: "Full-featured" VPN over an SSH tunnel
     it's disabled by default on openssh servers; plus it does
     TCP-over-TCP, which has suboptimal performance
  .
- It also has hooks for more complicated setups (VPN-in-a-SSH-VPN, etc) to allow
+ It also has hooks for more complicated setups (VPN-in-a-SSH-VPN, etc.) to allow
  you to set it up as you like.

--- a/packaging/control
+++ b/packaging/control
@@ -3,7 +3,7 @@ Version: 0+git
 Architecture: all
 Maintainer: Jim Wyllie <jwyllie83@gmail.com>
 Depends: autossh, iptables, python (>= 2.6)
-Section: utils
+Section: net
 Priority: optional
 Homepage: http://github.com/sshuttle/sshuttle
 Description: "Full-featured" VPN over an SSH tunnel

--- a/packaging/control
+++ b/packaging/control
@@ -2,7 +2,7 @@ Package: sshuttle
 Version: 0.2
 Architecture: all
 Maintainer: Jim Wyllie <jwyllie83@gmail.com>
-Depends: autossh, upstart, python (>=2.6)
+Depends: autossh, python (>=2.6)
 Section: utils
 Priority: optional
 Homepage: http://github.com/jwyllie83/sshuttle.udp

--- a/packaging/control
+++ b/packaging/control
@@ -1,6 +1,6 @@
 Package: sshuttle
 Version: 0.2
-Architecture: i386
+Architecture: all
 Maintainer: Jim Wyllie <jwyllie83@gmail.com>
 Depends: autossh, upstart, python (>=2.6)
 Section: utils

--- a/packaging/control
+++ b/packaging/control
@@ -5,7 +5,7 @@ Maintainer: Jim Wyllie <jwyllie83@gmail.com>
 Depends: autossh, python (>= 2.6)
 Section: utils
 Priority: optional
-Homepage: http://github.com/jwyllie83/sshuttle.udp
+Homepage: http://github.com/sshuttle/sshuttle
 Description: "Full-featured" VPN over an SSH tunnel, allowing full remote
  access somewhere where all you have is an SSH connection.  It works well if
  you generally find yourself in the following situation:

--- a/packaging/control
+++ b/packaging/control
@@ -1,5 +1,5 @@
 Package: sshuttle
-Version: 0.2
+Version: 0+git
 Architecture: all
 Maintainer: Jim Wyllie <jwyllie83@gmail.com>
 Depends: autossh, python (>= 2.6)

--- a/packaging/control
+++ b/packaging/control
@@ -2,7 +2,7 @@ Package: sshuttle
 Version: 0.2
 Architecture: all
 Maintainer: Jim Wyllie <jwyllie83@gmail.com>
-Depends: autossh, python (>=2.6)
+Depends: autossh, python (>= 2.6)
 Section: utils
 Priority: optional
 Homepage: http://github.com/jwyllie83/sshuttle.udp

--- a/packaging/make_deb
+++ b/packaging/make_deb
@@ -24,6 +24,8 @@ cp ../src/sshuttle ${B}/usr/bin
 cp -r sshuttle.conf ${B}/etc/init
 cp prefixes.conf ${B}/etc/sshuttle
 cp tunnel.conf ${B}/etc/sshuttle
+# Remove MacOS X stuff from .deb
+rm -r ${B}/usr/share/sshuttle/ui-macos
 
 # Copy the control file over, as well
 cp control ${B}/DEBIAN

--- a/packaging/make_deb
+++ b/packaging/make_deb
@@ -27,6 +27,9 @@ cp tunnel.conf ${B}/etc/sshuttle
 # Remove MacOS X stuff from .deb
 rm -r ${B}/usr/share/sshuttle/ui-macos
 
+# Fix path to main.py
+sed -e 's:^DIR=.*$:DIR=/usr/share/sshuttle/:' -i ${B}/usr/bin/sshuttle
+
 # Copy the control file over, as well
 cp control ${B}/DEBIAN
 


### PR DESCRIPTION
These commits fix the most blatant issues of the generated .deb:

* Not being installable on 64-bit systems due to wrong hardcoded architecture
* Not being installable on non-Ubuntu systems due to unnecessary dependency on `upstart`
* Non-working due to expecting `main.py` in `/usr/bin/`: `python2: can't open file '/usr/bin/main.py': [Errno 2] No such file or directory`

Additionally it fixes a bunch of minor but easy to fix issues I came across.

It also fixes the wrong statement that autossh is a hard dependency. It's just a nice-to-have.

Now the generated .deb at least works and is causing less issues for users who really want to use it (like breaking their installation by uninstalling 64-bit Python).

Nevertheless the generated .deb package is still ugly as hell and does not meet Debian's or Ubuntu's quality standards at all:

```
→ lintian ./sshuttle-0+git.deb
E: sshuttle: changelog-file-missing-in-native-package
E: sshuttle: file-in-etc-not-marked-as-conffile etc/init/sshuttle.conf
E: sshuttle: file-in-etc-not-marked-as-conffile etc/sshuttle/prefixes.conf
E: sshuttle: file-in-etc-not-marked-as-conffile etc/sshuttle/tunnel.conf
E: sshuttle: control-file-has-bad-owner md5sums abe/abe != root/root
E: sshuttle: no-copyright-file
W: sshuttle: possible-unindented-list-in-extended-description
E: sshuttle: wrong-file-owner-uid-or-gid etc/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid etc/init/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid etc/init/sshuttle.conf 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid etc/sshuttle/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid etc/sshuttle/post-stop.d/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid etc/sshuttle/pre-start.d/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid etc/sshuttle/prefixes.conf 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid etc/sshuttle/tunnel.conf 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/bin/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/bin/sshuttle 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/Makefile 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/all.do 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/assembler.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/clean.do 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/client.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/compat/ 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/compat/__init__.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/compat/ssubprocess.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/default.8.do 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/do 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/firewall.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/helpers.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/hostwatch.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/main.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/options.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/server.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/ssh.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/sshuttle 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/sshuttle.md 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/ssnet.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/ssyslog.py 1000/1000
E: sshuttle: wrong-file-owner-uid-or-gid usr/share/sshuttle/stresstest.py 1000/1000
W: sshuttle: binary-without-manpage usr/bin/sshuttle
```

I.e. I still cannot recommend to use that .deb. But at least it works and no more breaks the user's system.