### PR TITLE
Check for fileno attribute in _tty_width function

### DIFF
--- a/src/options.py
+++ b/src/options.py
@@ -61,6 +61,8 @@ def _remove_negative_k(k):
 
 
 def _tty_width():
+    if not hasattr(sys.stderr, "fileno"):
+        return _atoi(os.environ.get('WIDTH')) or 70
     s = struct.pack("HHHH", 0, 0, 0, 0)
     try:
         import fcntl


### PR DESCRIPTION
When using Options parser within a unittest.TextTestRunner with buffering enabled (buffer=True), it fails with: 
AttributeError: StringIO instance has no attribute 'fileno'

This change will prevent this kind of error.