### PR TITLE
Fix the excludes rule for OS X Yosemite and OS X El Captain

### DIFF
--- a/src/firewall.py
+++ b/src/firewall.py
@@ -499,7 +499,7 @@ def do_pf(port, dnsport, family, subnets, udp):
         exclude_subnets = filter(lambda s:s[2], sorted(subnets, reverse=True))
         if exclude_subnets:
             tables.append('table <exclude_subnets> {%s}' % ','.join(["%s/%s" % (n[3], n[1]) for n in exclude_subnets]))
-            filtering_rules.append('pass out route-to lo0 inet proto tcp to <exclude_subnets> keep state')
+            filtering_rules.append('pass out quick proto tcp from any to <exclude_subnets> keep state')
 
         if dnsport:
             nslist = resolvconf_nameservers()


### PR DESCRIPTION
Without this fix, the rdr rule is executed sending the packages that
should be excluded to the ssh tunnel, making the -x flag useless.

What I did was make sure that the packages that are going to the
excluded subnets are processed first and only after that, the remaining
packages will be sent to the ssh tunnel.

Thanks **Warr1024** on **#openssh** channel in freenode for telling me about
the **quick** keyword and the rest of people in the channel who tried to help.