### PR TITLE
Update ui-macos sources.list with new icon names

### DIFF
--- a/src/ui-macos/sources.list.do
+++ b/src/ui-macos/sources.list.do
@@ -4,9 +4,9 @@ cat <<-EOF
 	app.icns
 	MainMenu.nib English.lproj/MainMenu.nib
 	UserDefaults.plist
-	chicken-tiny.png
-	chicken-tiny-bw.png
-	chicken-tiny-err.png
+	ChickenIdleTemplate.pdf
+	ChickenRunningTemplate.pdf
+	ChickenErrorTemplate.pdf
 EOF
 for d in *.py sshuttle/*.py sshuttle/sshuttle sshuttle/compat/*.py; do
 	echo $d


### PR DESCRIPTION
I looks like building the app UI for OS X has been broken since https://github.com/sshuttle/sshuttle/commit/9eced8d0494e8d44b28db21f5643d824710c07a1 due to the *sources.list.do* file still referencing the old *.png* images.

Without this fix, the build will stop at:

    do            chicken-tiny.png
    do: Users/elasticdog/sshuttle/src/ui-macos/chicken-tiny.png: no .do file
    do:         Sshuttle VPN.app: got exit code 1
    do:       Sshuttle VPN.app.zip: got exit code 1
    do:     dist: got exit code 1
    do:   ui-macos/all: got exit code 1
    do: all: got exit code 1