### PR TITLE
dns: Added --ns-hosts to tunnel only some requests

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -48,10 +48,7 @@ def resolvconf_nameservers():
     for line in open('/etc/resolv.conf'):
         words = line.lower().split()
         if len(words) >= 2 and words[0] == 'nameserver':
-            if ':' in words[1]:
-                l.append((socket.AF_INET6, words[1]))
-            else:
-                l.append((socket.AF_INET, words[1]))
+            l.append(family_ip_tuple(words[1]))
     return l
 
 
@@ -80,6 +77,13 @@ def islocal(ip, family):
     finally:
         sock.close()
     return True  # it's a local IP, or there would have been an error
+
+
+def family_ip_tuple(ip):
+    if ':' in ip:
+        return (socket.AF_INET6, ip)
+    else:
+        return (socket.AF_INET, ip)
 
 
 def family_to_string(family):

--- a/src/main.py
+++ b/src/main.py
@@ -177,7 +177,6 @@ try:
         remotename = opt.remote
         if remotename == '' or remotename == '-':
             remotename = None
-        #nslist = re.split(r'[\s,]+', opt.dnshosts.strip()) if opt.dnshosts else []
         nslist = [family_ip_tuple(ns) for ns in parse_list(opt.ns_hosts)]
         if opt.seed_hosts and not opt.auto_hosts:
             o.fatal('--seed-hosts only works if you also use -H')


### PR DESCRIPTION
By default, the --dns flag configures the firewall to only intercept
queries made to the nameservers defined in resolvconf. This flag enables
the user to explicitly specify the nameservers which queries will be
redirected. This can be useful when the local nameserver forwards
queries to some domains to a nameserver on the remote site of the
tunnel.