### PR TITLE
Import resolvconf_nameservers, fix wrong types

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -215,7 +215,7 @@ try:
                                   opt.python,
                                   opt.latency_control,
                                   opt.dns,
-                                  opt.ns_hosts,
+                                  nslist,
                                   method,
                                   sh,
                                   opt.auto_nets,


### PR DESCRIPTION
Add resolvconf_nameservers to the list of functions imported from
helpers.
Fixed an instance where the method client.main was being called with
ns_hosts (string obtained from optional argument --ns-hosts) instead of
nslist (list of tuples that was already being passed to other methods).
Should fix issue #24.