### PR TITLE
Respect --syslog as soon as possible

### DIFF
--- a/sshuttle/__main__.py
+++ b/sshuttle/__main__.py
@@ -6,6 +6,7 @@ import sshuttle.options as options
 import sshuttle.client as client
 import sshuttle.firewall as firewall
 import sshuttle.hostwatch as hostwatch
+import sshuttle.ssyslog as ssyslog
 from sshuttle.helpers import family_ip_tuple, log, Fatal
 
 
@@ -197,6 +198,9 @@ try:
                     ipport_v6 = parse_ipport6(ip)
                 else:
                     ipport_v4 = parse_ipport4(ip)
+        if opt.syslog:
+            ssyslog.start_syslog()
+            ssyslog.stderr_to_syslog()
         return_code = client.main(ipport_v6, ipport_v4,
                                   opt.ssh_cmd,
                                   remotename,
@@ -209,7 +213,7 @@ try:
                                   opt.auto_nets,
                                   parse_subnets(includes),
                                   parse_subnets(excludes),
-                                  opt.syslog, opt.daemon, opt.pidfile)
+                                  opt.daemon, opt.pidfile)
 
         if return_code == 0:
             log('Normal exit code, exiting...')

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -81,8 +81,6 @@ def daemonize():
     os.dup2(si.fileno(), 1)
     si.close()
 
-    ssyslog.stderr_to_syslog()
-
 
 def daemon_cleanup():
     try:
@@ -382,8 +380,7 @@ def ondns(listener, method, mux, handlers):
 
 def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
           python, latency_control,
-          dns_listener, seed_hosts, auto_nets,
-          syslog, daemon):
+          dns_listener, seed_hosts, auto_nets, daemon):
 
     debug1('Starting client with Python version %s\n'
            % platform.python_version())
@@ -433,15 +430,11 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
     if initstring != expected:
         raise Fatal('expected server init string %r; got %r'
                     % (expected, initstring))
-    debug1('connected.\n')
-    print('Connected.')
+    log('Connected.\n')
     sys.stdout.flush()
     if daemon:
         daemonize()
         log('daemonizing (%s).\n' % _pidname)
-    elif syslog:
-        debug1('switching to syslog.\n')
-        ssyslog.stderr_to_syslog()
 
     def onroutes(routestr):
         if auto_nets:
@@ -493,10 +486,8 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
 def main(listenip_v6, listenip_v4,
          ssh_cmd, remotename, python, latency_control, dns, nslist,
          method_name, seed_hosts, auto_nets,
-         subnets_include, subnets_exclude, syslog, daemon, pidfile):
+         subnets_include, subnets_exclude, daemon, pidfile):
 
-    if syslog:
-        ssyslog.start_syslog()
     if daemon:
         try:
             check_daemon(pidfile)
@@ -644,8 +635,7 @@ def main(listenip_v6, listenip_v4,
     try:
         return _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
                      python, latency_control, dns_listener,
-                     seed_hosts, auto_nets, syslog,
-                     daemon)
+                     seed_hosts, auto_nets, daemon)
     finally:
         try:
             if daemon:


### PR DESCRIPTION
When executing with the option --syslog start redirecting to
syslog immediately after the command line options are validated.
This way when using with some init daemon, e.g., upstart all the
relevant information (connection failures, etc) can be retrieved from
the log instead of being lost to stdout or stderr.