### PR TITLE
Fixed str being used as bytes in daemonize

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -67,7 +67,7 @@ def daemonize():
 
     outfd = os.open(_pidname, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
     try:
-        os.write(outfd, '%d\n' % os.getpid())
+        os.write(outfd, b'%d\n' % os.getpid())
     finally:
         os.close(outfd)
     os.chdir("/")


### PR DESCRIPTION
Fixes the following error when --daemon is used with Python 3.
```
 Traceback (most recent call last):
   File "/usr/lib/python3.5/runpy.py", line 170, in _run_module_as_main
     "__main__", mod_spec)
   File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
     exec(code, run_globals)
   File "/root/sshuttle/sshuttle/__main__.py", line 216, in <module>
     opt.daemon, opt.pidfile)
   File "/root/sshuttle/sshuttle/client.py", line 640, in main
     seed_hosts, auto_nets, daemon)
   File "/root/sshuttle/sshuttle/client.py", line 438, in _main
     daemonize()
   File "/root/sshuttle/sshuttle/client.py", line 70, in daemonize
     os.write(outfd, '%d\n' % os.getpid())
TypeError: a bytes-like object is required, not 'str'
```