### PR TITLE
Fixed dictionary changed size during iteration

### DIFF
--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -334,8 +334,8 @@ def main(latency_control):
                     debug3('expiring dnsreqs channel=%d\n' % channel)
                     remove.append(channel)
                     h.ok = False
-                for channel in remove:
-                    del dnshandlers[channel]
+            for channel in remove:
+                del dnshandlers[channel]
         if udphandlers:
             remove = []
             for channel, h in udphandlers.items():
@@ -343,5 +343,5 @@ def main(latency_control):
                     debug3('expiring UDP channel=%d\n' % channel)
                     remove.append(channel)
                     h.ok = False
-                for channel in remove:
-                    del udphandlers[channel]
+            for channel in remove:
+                del udphandlers[channel]


### PR DESCRIPTION
The removal loop should probably be outside the iteration loop. Probably a typo while you were fixing this?

```
Starting sshuttle proxy.
firewall manager: Starting firewall with Python version 2.7.9
firewall manager: ready method name pf.
UDP enabled: False
Binding redirector: 12300
TCP redirector listening on ('127.0.0.1', 12300).
TCP redirector listening with <socket._socketobject object at 0x80431f130>.
Binding DNS: 12300
DNS listening on ('127.0.0.1', 12300).
DNS listening with <socket._socketobject object at 0x80431f360>.
Starting client with Python version 2.7.9
c : connecting to server...
c : executing: ['ssh', 'root@192.241.238.19', '--', 'P=python3.5; $P -V 2>/dev/null || P=python; exec "$P" -c \'import sys, os; verbosity=3; sys.stdin = os.fdopen(0, "rb"); exec(compile(sys.stdin.read(937), "assembler.py", "exec"))\'']
c :  > channel=0 cmd=PING len=7 (fullness=0)
server: assembling 'sshuttle' (7 bytes)
server: assembling 'sshuttle.cmdline_options' (27 bytes)
server: assembling 'sshuttle.helpers' (853 bytes)
server: assembling 'sshuttle.ssnet' (5543 bytes)
server: assembling 'sshuttle.hostwatch' (2338 bytes)
server: assembling 'sshuttle.server' (3081 bytes)
Starting server with Python version 3.5.0
 s: latency control setting = True
 s: available routes:
 s:   2/10.12.0.0/16
 s:   2/192.241.238.0/24
 s:  > channel=0 cmd=PING len=7 (fullness=0)
 s:  > channel=0 cmd=ROUTES len=34 (fullness=7)
c : Connected.
c : Waiting: 3 r=[7, 8, 9] w=[9] x=[] (fullness=7/0)
c :   Ready: 3 r=[] w=[9] x=[]
c : mux wrote: 15/15
c : Waiting: 3 r=[7, 8, 9] w=[] x=[] (fullness=7/0)
c :   Ready: 3 r=[9] w=[] x=[]
 s: Waiting: 1 r=[4] w=[5] x=[] (fullness=41/0)
 s:   Ready: 1 r=[] w=[5] x=[]
 s: mux wrote: 15/15
 s: Waiting: 1 r=[4] w=[5] x=[] (fullness=41/0)
 s:   Ready: 1 r=[] w=[5] x=[]
 s: mux wrote: 42/42
 s: Waiting: 1 r=[4] w=[] x=[] (fullness=41/0)
c : <  channel=0 cmd=PING len=7
c :  > channel=0 cmd=PONG len=7 (fullness=7)
c : <  channel=0 cmd=ROUTES len=34
firewall manager: Got subnets: [(2, 8, False, '216.0.0.0'), (2, 8, True, '127.0.0.0')]
firewall manager: Got partial nslist: [(2, '8.8.8.8')]
firewall manager: Got partial nslist: [(2, '8.8.8.8'), (2, '8.8.4.4')]
firewall manager: Got nslist: [(2, '8.8.8.8'), (2, '8.8.4.4')]
firewall manager: Got ports: 0,12300,0,12300
firewall manager: Got udp: False
firewall manager: setting up.
firewall manager: setting up IPv4.
>> pfctl -s all
>> pfctl -a sshuttle -f /dev/stdin
c : mux wrote: 15/15
c : Waiting: 3 r=[7, 8, 9] w=[] x=[] (fullness=14/0)
 s:   Ready: 1 r=[4] w=[] x=[]
 s: <  channel=0 cmd=PING len=7
 s:  > channel=0 cmd=PONG len=7 (fullness=41)
 s: mux wrote: 15/15
 s: Waiting: 1 r=[4] w=[] x=[] (fullness=48/0)
c :   Ready: 3 r=[9] w=[] x=[]
c : <  channel=0 cmd=PONG len=7
c : received PING response
c : Waiting: 3 r=[7, 8, 9] w=[] x=[] (fullness=0/0)
 s:   Ready: 1 r=[4] w=[] x=[]
 s: <  channel=0 cmd=PONG len=7
 s: received PING response
 s: Waiting: 1 r=[4] w=[] x=[] (fullness=0/0)
c :   Ready: 3 r=[8] w=[] x=[]
c : Accept UDP using recvfrom.
c : DNS request from ('46.101.80.172', 24063) to None: 28 bytes
c :  > channel=1 cmd=DNS_REQ len=28 (fullness=0)
c : Remaining DNS requests: 1
c : Remaining UDP channels: 0
  : Waiting: 3 r=[7, 8, 9] w=[9] x=[] (fullness=28/0)
c :   Ready: 3 r=[] w=[9] x=[]
c : mux wrote: 36/36
c : Waiting: 3 r=[7, 8, 9] w=[] x=[] (fullness=28/0)
 s:   Ready: 1 r=[4] w=[] x=[]
 s: <  channel=1 cmd=DNS_REQ len=28
 s: Incoming DNS request channel=1.
 s: DNS: sending to '8.8.4.4' (try 1)
 s: Waiting: 2 r=[4, 7] w=[] x=[] (fullness=0/0)
 s:   Ready: 2 r=[7] w=[] x=[]
 s: DNS response: 44 bytes
 s:  > channel=1 cmd=DNS_RESPONSE len=44 (fullness=0)
 s: expiring dnsreqs channel=1
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "assembler.py", line 35, in <module>
  File "sshuttle.server", line 336, in main
RuntimeError: dictionary changed size during iteration
c :   Ready: 3 r=[9] w=[] x=[]
firewall manager: undoing changes.
firewall manager: undoing IPv4 changes.
>> pfctl -a sshuttle -F all
firewall manager: undoing /etc/hosts changes.
c : fatal: server died with error code 1
```