### PR TITLE
Fixed instances of str being used as bytes

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -335,7 +335,7 @@ def onaccept_tcp(listener, method, mux, handlers):
 
 
 def udp_done(chan, data, method, sock, dstip):
-    (src, srcport, data) = data.split(",", 2)
+    (src, srcport, data) = data.split(b",", 2)
     srcip = (src, int(srcport))
     debug3('doing send from %r to %r\n' % (srcip, dstip,))
     method.send_udp(sock, srcip, dstip, data)
@@ -354,10 +354,11 @@ def onaccept_udp(listener, method, mux, handlers):
         chan = mux.next_channel()
         mux.channels[chan] = lambda cmd, data: udp_done(
             chan, data, method, listener, dstip=srcip)
-        mux.send(chan, ssnet.CMD_UDP_OPEN, listener.family)
+        mux.send(chan, ssnet.CMD_UDP_OPEN,
+                 str(int(listener.family).encode("ASCII"))
     udp_by_src[srcip] = chan, now + 30
 
-    hdr = "%s,%r," % (dstip[0], dstip[1])
+    hdr = ("%s,%r," % (dstip[0], dstip[1])).encode("ASCII")
     mux.send(chan, ssnet.CMD_UDP_DATA, hdr + data)
 
     expire_connections(now, mux)


### PR DESCRIPTION
This should fix one of the problems in #45. Once PR #37 is merged maybe we can make use of
b() to make these conversions.