### PR TITLE
Adds support for FreeBSD PF

### DIFF
--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -228,9 +228,9 @@ class Method(BaseMethod):
 
         pf_status = pfctl('-s all')[0]
         if b'\nrdr-anchor "sshuttle" all\n' not in pf_status:
-            pf_add_anchor_rule(PF_RDR, "sshuttle")
+            pf_add_anchor_rule(PF_RDR, b"sshuttle")
         if b'\nanchor "sshuttle" all\n' not in pf_status:
-            pf_add_anchor_rule(PF_PASS, "sshuttle")
+            pf_add_anchor_rule(PF_PASS, b"sshuttle")
 
         pfctl('-a sshuttle -f /dev/stdin', rules)
         if sys.platform == "darwin":


### PR DESCRIPTION
The PF firewall that is included in the FreeBSD base system does not
have exactly the same data structures as the OSX version. This commit
fixes the offsets and some field types that are also different. Tested
with FreeBSD 10.2 and OSX 10.11.2.