### PR TITLE
fixes the sshuttle entry-point in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'sshuttle = sshuttle.__main__',
+            'sshuttle = sshuttle:__main__',
         ],
     },
     tests_require=['pytest', 'mock'],


### PR DESCRIPTION
This fixes the following error:

    "import_name": entry.suffix.split(".")[0],
    AttributeError: 'NoneType' object has no attribute 'split'

See
https://pythonhosted.org/setuptools/setuptools.html#automatic-script-creation