### PR TITLE
Don't crash if ipv6 is not available

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -95,7 +95,10 @@ def daemon_cleanup():
 class MultiListener:
 
     def __init__(self, type=socket.SOCK_STREAM, proto=0):
-        self.v6 = socket.socket(socket.AF_INET6, type, proto)
+        try:
+            self.v6 = socket.socket(socket.AF_INET6, type, proto)
+        except:
+            self.v6 = None
         self.v4 = socket.socket(socket.AF_INET, type, proto)
 
     def setsockopt(self, level, optname, value):


### PR DESCRIPTION
I am getting `OSError: [Errno 97] Address family not supported by protocol` on this line.  Adding --disable-ipv6 does not help.  However, enclosing the line in a try/except block appears to solve the problem. 