### PR TITLE
fix byte/string bug introduced in 1c46f25e

### DIFF
--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -257,7 +257,7 @@ def main(latency_control):
             if lines[-1]:
                 # no terminating newline: entry isn't complete yet!
                 hw.leftover = lines.pop()
-                lines.append('')
+                lines.append(b'')
             else:
                 hw.leftover = b''
             mux.send(0, ssnet.CMD_HOST_LIST, b'\n'.join(lines))


### PR DESCRIPTION
This is the error message that this commit fixes:
TypeError: sequence item 142: expected a bytes-like object, str found

Complete what 1c46f25e started, more or less.