### PR TITLE
Explicitly call /bin/sh for compatibility with non POSIX shells.

### DIFF
--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -108,8 +108,8 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
         if python:
             pycmd = "'%s' -c '%s'" % (python, pyscript)
         else:
-            pycmd = ("P=python3.5; $P -V 2>/dev/null || P=python; "
-                     "exec \"$P\" -c '%s'") % pyscript
+            pycmd = ("exec /bin/sh -c \'P=python3.5; $P -V 2>/dev/null || P=python; "
+                     "exec \"$P\" -c \\'%s\\'\'") % pyscript
         argv = (sshl +
                 portl +
                 [rhost, '--', pycmd])


### PR DESCRIPTION
The fish shell doesn’t support ‘||’ and requires a ‘—python python’
workaround.  This change explicitly calls /bin/sh for the remote shell
commands.

This fixes issue #76 that I opened.
