### PR TITLE
If 3.5 not available, try to fallback to 2.7

### DIFF
--- a/run
+++ b/run
@@ -1,6 +1,8 @@
 #!/bin/sh
 if python3.5 -V 2>/dev/null; then
 	exec python3.5 -m "sshuttle" "$@"
+elif python2.7 -V 2>/dev/null; then
+    exec python2.7 -m "sshuttle" "$@"
 else
 	exec python -m "sshuttle" "$@"
 fi


### PR DESCRIPTION
In situations where 2.7 is available and some unsupported 3.x is the
system's default we should probably fallback to 2.7 instead of the
default (that might be e.g. 3.4). This might fix #78.