### PR TITLE
Remove --server option

### DIFF
--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -290,13 +290,6 @@ parser.add_argument(
     """
 )
 parser.add_argument(
-    "--server",
-    action="store_true",
-    help="""
-    (internal use only)
-    """
-)
-parser.add_argument(
     "--firewall",
     action="store_true",
     help="""


### PR DESCRIPTION
As @brianmay observed in #82 this option is no longer used and can be
dropped.