### PR TITLE
Support multiple subnet files (multiple -s options)

### DIFF
--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -26,7 +26,7 @@ def main():
         elif opt.hostwatch:
             return hostwatch.hw_main(opt.subnets)
         else:
-            includes = opt.subnets_from_file or opt.subnets
+            includes = opt.subnets
             excludes = opt.exclude
             if not includes and not opt.auto_nets:
                 parser.error('at least one subnet, subnet file, or -N expected')

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -268,7 +268,8 @@ parser.add_argument(
 parser.add_argument(
     "-s", "--subnets",
     metavar="PATH",
-    dest="subnets_from_file",
+    action=Concat,
+    dest="subnets",
     type=parse_subnet_file,
     help="""
     file where the subnets are stored, instead of on the command line


### PR DESCRIPTION
When passing multiple subnet files, e.g., by using -s/--subnets
multiple times or by using it together with subnets passed as positional
arguments append the content from all sources instead of only using the
subnets from the last source. This makes the behaviour of -s/--subnets
consistent with -x/--exclude and -X/--exclude-from.