### PR TITLE
Correctly obtains the python executable to use

### DIFF
--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -105,7 +105,7 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
     if not rhost:
         # ignore the --python argument when running locally; we already know
         # which python version works.
-        argv = [sys.argv[1], '-c', pyscript]
+        argv = [sys.executable, '-c', pyscript]
     else:
         if ssh_cmd:
             sshl = ssh_cmd.split(' ')


### PR DESCRIPTION
Previously the sshuttle shell script would pass the python to use as the
first argument of the command. The new run script no longer does this.
Instead we can obtain the python being used via sys.executable.
Fixes #88.