### PR TITLE
Don't mix tab and spaces in shell script

### DIFF
--- a/run
+++ b/run
@@ -1,8 +1,8 @@
 #!/bin/sh
 if python3.5 -V 2>/dev/null; then
-    exec python3.5 -m "sshuttle" "$@"
+	exec python3.5 -m "sshuttle" "$@"
 elif python2.7 -V 2>/dev/null; then
-    exec python2.7 -m "sshuttle" "$@"
+	exec python2.7 -m "sshuttle" "$@"
 else
 	exec python -m "sshuttle" "$@"
 fi

--- a/run
+++ b/run
@@ -1,6 +1,6 @@
 #!/bin/sh
 if python3.5 -V 2>/dev/null; then
-	exec python3.5 -m "sshuttle" "$@"
+    exec python3.5 -m "sshuttle" "$@"
 elif python2.7 -V 2>/dev/null; then
     exec python2.7 -m "sshuttle" "$@"
 else


### PR DESCRIPTION
Sometime ago I was in python mode and incorrectly indented a line of the
shell script with spaces instead of tabs. Shame on me. This should bring
things back to their natural order.