### PR TITLE
Hack pf to enable multiple instances in Mac OS X 10.10 and above

### DIFF
--- a/sshuttle/tests/client/test_methods_pf.py
+++ b/sshuttle/tests/client/test_methods_pf.py
@@ -217,7 +217,7 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     assert mock_pfctl.mock_calls == [
         call('-f /dev/stdin', b'pass on lo\n'),
         call('-s all'),
-        call('-a sshuttle -f /dev/stdin',
+        call('-a sshuttle-1025 -f /dev/stdin',
              b'table <forward_subnets> {!1.2.3.66/32,1.2.3.0/24}\n'
              b'table <dns_servers> {1.2.3.33}\n'
              b'rdr pass on lo0 proto tcp '
@@ -237,7 +237,7 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     method.restore_firewall(1025, 2, False)
     assert mock_ioctl.mock_calls == []
     assert mock_pfctl.mock_calls == [
-        call('-a sshuttle -F all'),
+        call('-a sshuttle-1025 -F all'),
         call("-X abcdefg"),
     ]
     mock_pf_get_dev.reset_mock()
@@ -298,7 +298,7 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     ]
     assert mock_pfctl.mock_calls == [
         call('-s all'),
-        call('-a sshuttle -f /dev/stdin',
+        call('-a sshuttle-1025 -f /dev/stdin',
              b'table <forward_subnets> {!1.2.3.66/32,1.2.3.0/24}\n'
              b'table <dns_servers> {1.2.3.33}\n'
              b'rdr pass on lo0 proto tcp '
@@ -318,7 +318,7 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     method.restore_firewall(1025, 2, False)
     assert mock_ioctl.mock_calls == []
     assert mock_pfctl.mock_calls == [
-        call('-a sshuttle -F all'),
+        call('-a sshuttle-1025 -F all'),
         call("-d"),
     ]
     mock_pf_get_dev.reset_mock()
@@ -376,7 +376,7 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     assert mock_pfctl.mock_calls == [
         call('-f /dev/stdin', b'match on lo\n'),
         call('-s all'),
-        call('-a sshuttle -f /dev/stdin',
+        call('-a sshuttle-1025 -f /dev/stdin',
              b'table <forward_subnets> {!1.2.3.66/32,1.2.3.0/24}\n'
              b'table <dns_servers> {1.2.3.33}\n'
              b'pass in on lo0 inet proto tcp divert-to 127.0.0.1 port 1025\n'
@@ -395,7 +395,7 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     method.restore_firewall(1025, 2, False)
     assert mock_ioctl.mock_calls == []
     assert mock_pfctl.mock_calls == [
-        call('-a sshuttle -F all'),
+        call('-a sshuttle-1025 -F all'),
         call("-d"),
     ]
     mock_pf_get_dev.reset_mock()

--- a/sshuttle/tests/client/test_methods_pf.py
+++ b/sshuttle/tests/client/test_methods_pf.py
@@ -379,7 +379,7 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         call('-a sshuttle-1025 -f /dev/stdin',
              b'table <forward_subnets> {!1.2.3.66/32,1.2.3.0/24}\n'
              b'table <dns_servers> {1.2.3.33}\n'
-             b'pass in on lo0 inet proto tcp divert-to 127.0.0.1 port 1025\n'
+             b'pass in on lo0 inet proto tcp to <forward_subnets> divert-to 127.0.0.1 port 1025\n'
              b'pass in on lo0 inet proto udp to '
              b'<dns_servers>port 53 rdr-to 127.0.0.1 port 1027\n'
              b'pass out inet proto tcp to '


### PR DESCRIPTION
# Why
To run multiple times simultaneously on Mac OS X 10.10 and above.

# Changes
Use different anchor name for different instance.
Except for the first instance, do not override the skip lo.

# Tests
Tested with OS X El Capitan version 10.11.5