### PR TITLE
Allow subnets to be given only by file (-s)

### DIFF
--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -20,13 +20,13 @@ def main():
 
     try:
         if opt.firewall:
-            if opt.subnets:
+            if opt.subnets or opt.subnets_file:
                 parser.error('exactly zero arguments expected')
             return firewall.main(opt.method, opt.syslog)
         elif opt.hostwatch:
             return hostwatch.hw_main(opt.subnets)
         else:
-            includes = opt.subnets
+            includes = opt.subnets + opt.subnets_file
             excludes = opt.exclude
             if not includes and not opt.auto_nets:
                 parser.error('at least one subnet, subnet file, '

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -106,7 +106,7 @@ class Concat(Action):
         super(Concat, self).__init__(option_strings, dest, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        curr_value = getattr(namespace, self.dest, [])
+        curr_value = getattr(namespace, self.dest, None) or []
         setattr(namespace, self.dest, curr_value + values)
 
 
@@ -269,7 +269,7 @@ parser.add_argument(
     "-s", "--subnets",
     metavar="PATH",
     action=Concat,
-    dest="subnets",
+    dest="subnets_file",
     type=parse_subnet_file,
     help="""
     file where the subnets are stored, instead of on the command line


### PR DESCRIPTION
This should fix #116. Handling this while still having the positional
arguments and -s both write to the same list turned out to be more
complicated than it's worth so each writes to their own variable and we
merge them at the end.