### PR TITLE
Fix #117 to allow for no subnets via file (-s)

### DIFF
--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -270,6 +270,7 @@ parser.add_argument(
     metavar="PATH",
     action=Concat,
     dest="subnets_file",
+    default=[],
     type=parse_subnet_file,
     help="""
     file where the subnets are stored, instead of on the command line


### PR DESCRIPTION
This should fix an issue introduced in #117 where when no subnets are
given via file (-s file) the variable is None instead of an empty list
and the concatenation with the subnets given as positional parameters
fails.

This should the issue reported on #116 by @ccwufu.