### PR TITLE
Move pytest-runner to tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'write_to': "sshuttle/version.py",
         'version_scheme': version_scheme,
     },
-    setup_requires=['setuptools_scm', 'pytest-runner'],
+    setup_requires=['setuptools_scm'],
     # version=version,
     url='https://github.com/sshuttle/sshuttle',
     author='Brian May',
@@ -61,6 +61,6 @@ setup(
             'sshuttle = sshuttle.cmdline:main',
         ],
     },
-    tests_require=['pytest', 'mock'],
+    tests_require=['pytest', 'pytest-runner', 'mock'],
     keywords="ssh vpn",
 )


### PR DESCRIPTION
As it is only required to run the tests move pytest-runner from
setup_requires to tests_require as suggested by @jonathanunderwood
on #115.