### PR TITLE
Set started_by_sshuttle False after disabling pf

### DIFF
--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -64,6 +64,7 @@ class Generic(object):
         pfctl('-a %s -F all' % anchor)
         if _pf_context['started_by_sshuttle']:
             pfctl('-d')
+            _pf_context['started_by_sshuttle'] = False
 
     def query_nat(self, family, proto, src_ip, src_port, dst_ip, dst_port):
         [proto, family, src_port, dst_port] = [


### PR DESCRIPTION
We set it to true when we enable pf, but do not set it back to False
after disabling. When using IPv4 and IPv6 we end up trying to disable
twice which produces an error while undoing changes in FreeBSD 11.