### PR TITLE
Add support for pfSense

### DIFF
--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import platform
 import re
 import socket
 import struct
@@ -335,10 +336,20 @@ class Darwin(FreeBsd):
         return xport.port
 
 
+class PfSense(FreeBsd):
+    RULE_ACTION_OFFSET = 3040
+
+    def __init__(self):
+        self.pfioc_rule = c_char * 3112
+        super(PfSense, self).__init__()
+
+
 if sys.platform == 'darwin':
     pf = Darwin()
 elif sys.platform.startswith('openbsd'):
     pf = OpenBsd()
+elif platform.version().endswith('pfSense'):
+    pf = PfSense()
 else:
     pf = FreeBsd()
 


### PR DESCRIPTION
pfSense is based on FreeBSD and its pf is pretty close to the one
FreeBSD ships, however some structures have different fields and two
offsets had to be fixed.

This should fix #107 and #100.

Still would like to write unit tests and check if it works with other machines using pfsense as firewall/gateway (only tested from the machine running pfSense itself).