### PR TITLE
Add support for iproute2

### DIFF
--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -66,23 +66,19 @@ def _shl(n, bits):
 
 
 def _route_netstat(line):
-    cols = re.split(r'\s+', line.decode("ASCII"))
+    cols = line.split(None)
     ipw = _ipmatch(cols[0])
-    if not ipw:
-        return None, None  # some lines won't be parseable; never mind
     maskw = _ipmatch(cols[2])  # linux only
     mask = _maskbits(maskw)   # returns 32 if maskw is null
     return ipw, mask
 
 
 def _route_iproute(line):
-    ipm = line.decode("ASCII").split(None, 1)[0]
-    if ipm == 'default':
+    ipm = line.split(None, 1)[0]
+    if '/' not in ipm:
         return None, None
     ip, mask = ipm.split('/')
     ipw = _ipmatch(ip)
-    if not ipw:
-        return None, None  # some lines won't be parseable; never mind
     return ipw, int(mask)
 
 
@@ -95,7 +91,9 @@ def _list_routes(argv, extract_route):
     p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=env)
     routes = []
     for line in p.stdout:
-        ipw, mask = extract_route(line)
+        if not line.strip():
+            continue
+        ipw, mask = extract_route(line.decode("ASCII"))
         if not ipw:
             continue
         width = min(ipw[1], mask)

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -15,6 +15,11 @@ from sshuttle.ssnet import Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import b, log, debug1, debug2, debug3, Fatal, \
     resolvconf_random_nameserver
 
+try:
+    from shutil import which
+except ImportError:
+    from distutils.spawn import find_executable as which
+
 
 def _ipmatch(ipstr):
     # FIXME: IPv4 only
@@ -60,9 +65,29 @@ def _shl(n, bits):
     return n * int(2 ** bits)
 
 
-def _list_routes():
+def _route_netstat(line):
+    cols = re.split(r'\s+', line.decode("ASCII"))
+    ipw = _ipmatch(cols[0])
+    if not ipw:
+        return None, None  # some lines won't be parseable; never mind
+    maskw = _ipmatch(cols[2])  # linux only
+    mask = _maskbits(maskw)   # returns 32 if maskw is null
+    return ipw, mask
+
+
+def _route_iproute(line):
+    ipm = line.decode("ASCII").split(None, 1)[0]
+    if ipm == 'default':
+        return None, None
+    ip, mask = ipm.split('/')
+    ipw = _ipmatch(ip)
+    if not ipw:
+        return None, None  # some lines won't be parseable; never mind
+    return ipw, int(mask)
+
+
+def _list_routes(argv, extract_route):
     # FIXME: IPv4 only
-    argv = ['netstat', '-rn']
     env = {
         'PATH': os.environ['PATH'],
         'LC_ALL': "C",
@@ -70,12 +95,9 @@ def _list_routes():
     p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=env)
     routes = []
     for line in p.stdout:
-        cols = re.split(r'\s+', line.decode("ASCII"))
-        ipw = _ipmatch(cols[0])
+        ipw, mask = extract_route(line)
         if not ipw:
-            continue  # some lines won't be parseable; never mind
-        maskw = _ipmatch(cols[2])  # linux only
-        mask = _maskbits(maskw)   # returns 32 if maskw is null
+            continue
         width = min(ipw[1], mask)
         ip = ipw[0] & _shl(_shl(1, width) - 1, 32 - width)
         routes.append(
@@ -84,11 +106,20 @@ def _list_routes():
     if rv != 0:
         log('WARNING: %r returned %d\n' % (argv, rv))
         log('WARNING: That prevents --auto-nets from working.\n')
+
     return routes
 
 
 def list_routes():
-    for (family, ip, width) in _list_routes():
+    if which('ip'):
+        routes = _list_routes(['ip', 'route'], _route_iproute)
+    elif which('netstat'):
+        routes = _list_routes(['netstat', '-rn'], _route_netstat)
+    else:
+        log('WARNING: Neither ip nor netstat were found on the server.\n')
+        routes = []
+
+    for (family, ip, width) in routes:
         if not ip.startswith('0.') and not ip.startswith('127.'):
             yield (family, ip, width)
 

--- a/sshuttle/tests/server/test_server.py
+++ b/sshuttle/tests/server/test_server.py
@@ -21,8 +21,9 @@ def test__maskbits():
     sshuttle.server._maskbits(netmask)
 
 
+@patch('sshuttle.server.which', side_effect=lambda x: x == 'netstat')
 @patch('sshuttle.server.ssubprocess.Popen')
-def test__listroutes(mock_popen):
+def test_listroutes_netstat(mock_popen, mock_which):
     mock_pobj = Mock()
     mock_pobj.stdout = io.BytesIO(b"""
 Kernel IP routing table
@@ -33,30 +34,20 @@ Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
     mock_pobj.wait.return_value = 0
     mock_popen.return_value = mock_pobj
 
-    routes = sshuttle.server._list_routes()
+    routes = sshuttle.server.list_routes()
 
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
-    assert mock_popen.mock_calls == [
-        call(['netstat', '-rn'], stdout=-1, env=env),
-        call().wait()
-    ]
-    assert routes == [
-        (socket.AF_INET, '0.0.0.0', 0),
+    assert list(routes) == [
         (socket.AF_INET, '192.168.1.0', 24)
     ]
 
 
+@patch('sshuttle.server.which', side_effect=lambda x: x == 'ip')
 @patch('sshuttle.server.ssubprocess.Popen')
-def test_listroutes(mock_popen):
+def test_listroutes_iproute(mock_popen, mock_which):
     mock_pobj = Mock()
     mock_pobj.stdout = io.BytesIO(b"""
-Kernel IP routing table
-Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
-0.0.0.0         192.168.1.1     0.0.0.0         UG        0 0          0 wlan0
-192.168.1.0     0.0.0.0         255.255.255.0   U         0 0          0 wlan0
+default via 192.168.1.1 dev wlan0  proto static 
+192.168.1.0/24 dev wlan0  proto kernel  scope link  src 192.168.1.1
 """)
     mock_pobj.wait.return_value = 0
     mock_popen.return_value = mock_pobj


### PR DESCRIPTION
`netstat` has been deprecated for some time and some distros might
start shipping without it in the near future. This commit adds support
for `ip route` and uses it when available.

This should fix issues like the one reported in #131.