### PR TITLE
Fix UDP and DNS support on Python 2.7 with tproxy method

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -1,4 +1,3 @@
-import socket
 import errno
 import re
 import signal
@@ -16,6 +15,20 @@ from sshuttle.ssnet import SockWrapper, Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import log, debug1, debug2, debug3, Fatal, islocal, \
     resolvconf_nameservers
 from sshuttle.methods import get_method, Features
+
+try:
+    # try getting recvmsg from python
+    import socket as pythonsocket
+    getattr(pythonsocket.socket, "recvmsg")
+    socket = pythonsocket
+except AttributeError:
+    # try getting recvmsg from socket_ext library
+    try:
+        import socket_ext
+        getattr(socket_ext.socket, "recvmsg")
+        socket = socket_ext
+    except ImportError:
+        import socket
 
 _extra_fd = os.open('/dev/null', os.O_RDONLY)
 


### PR DESCRIPTION
There was runtime failure on UDP or DNS processing, because "socket" was redefined to PyXAPI's socket_ext in tproxy.py, but still was plain Python's socket in client.py
Fixed https://github.com/sshuttle/sshuttle/issues/134 for me