### PR TITLE
Work around non tabular headers in BSD netstat

### DIFF
--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -67,6 +67,8 @@ def _shl(n, bits):
 
 def _route_netstat(line):
     cols = line.split(None)
+    if len(cols) < 3:
+        return None, None
     ipw = _ipmatch(cols[0])
     maskw = _ipmatch(cols[2])  # linux only
     mask = _maskbits(maskw)   # returns 32 if maskw is null


### PR DESCRIPTION
netstat outputs some headers in BSD (that the Linux version does not)
that are not tabular and were breaking our 'split line into columns
and get nth column' logic. We now skip such headers.

Should fix #141.