### PR TITLE
Order first by port range and only then by swidth

### DIFF
--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -75,12 +75,13 @@ def setup_daemon():
 
 
 # Note that we're sorting in a very particular order:
-# we need to go from most-specific (largest swidth) to least-specific,
-# and at any given level of specificity, smaller port ranges come
-# before larger port ranges. On ties excludes come first.
+# we need to go from smaller, more specific, port ranges, to larger,
+# less-specific, port ranges. At each level, we order by subnet
+# width, from most-specific subnets (largest swidth) to
+# least-specific. On ties, excludes come first.
 # s:(inet, subnet width, exclude flag, subnet, first port, last port)
 def subnet_weight(s):
-    return (s[1], s[-2] or -65535 - s[-1], s[2])
+    return (-s[-1] + (s[-2] or -65535), s[1], s[2])
 
 
 # This is some voodoo for setting up the kernel's transparent


### PR DESCRIPTION
This change makes the subnets with the most specific port ranges come
before subnets with larger, least specific, port ranges. Before this
change subnets with smaller swidth would always come first and only for
subnets with the same width would the size of the port range be
considered.

Example:
188.0.0.0/8 -x 0.0.0.0/0:443
Before: 188.0.0.0/8 would come first meaning that all ports would be
routed through the VPN for the subnet 188.0.0.0/8
After: 0.0.0.0/0:443 comes first, meaning that port 443 will be
excluded for all subnets, including 188.0.0.0/8. All other ports of
188.0.0.0/8 will be routed.