### PR TITLE
Support custom DNS server when proxying DNS

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -34,4 +34,4 @@ sshuttle.helpers.verbose = verbosity
 
 import sshuttle.cmdline_options as options
 from sshuttle.server import main
-main(options.latency_control, options.auto_hosts)
+main(options.latency_control, options.auto_hosts, options.to_nameserver)

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -553,6 +553,9 @@ def main(listenip_v6, listenip_v4,
         nslist += resolvconf_nameservers()
         if to_nameserver is not None:
             to_nameserver = "%s@%s" % tuple(to_nameserver[1:])
+    else:
+        # option doesn't make sense if we aren't proxying dns
+        to_nameserver = None
 
     subnets = subnets_include + subnets_exclude  # we don't care here
     subnets_v6 = [i for i in subnets if i[0] == socket.AF_INET6]

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -73,7 +73,9 @@ def main():
                                       opt.auto_nets,
                                       includes,
                                       excludes,
-                                      opt.daemon, opt.pidfile)
+                                      opt.daemon,
+                                      opt.to_ns,
+                                      opt.pidfile)
 
             if return_code == 0:
                 log('Normal exit code, exiting...')

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -147,6 +147,15 @@ parser.add_argument(
     """
 )
 parser.add_argument(
+    "--to-ns",
+    metavar="IP[:PORT]",
+    type=parse_ipport,
+    help="""
+    the DNS server to forward requests to; defaults to servers in /etc/resolv.conf on remote side if not given.
+    """
+)
+
+parser.add_argument(
     "--method",
     choices=["auto", "nat", "tproxy", "pf", "ipfw"],
     metavar="TYPE",

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -179,7 +179,10 @@ class DnsProxy(Handler):
 
         sock = socket.socket(family, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_IP, socket.IP_TTL, 42)
-        sock.connect((peer, 53))
+        # Connect to custom DNS server running in the Telepresence pod:
+        # XXX eventually this should be configured via command-line
+        # option and submitted to upstream as improvement.
+        sock.connect(('127.0.0.1', 9053))
 
         self.peers[sock] = peer
 


### PR DESCRIPTION
I am using sshuttle in http://telepresence.io. Part of what I do involves proxying to a custom DNS server, not the one in /etc/resolv.conf on the server-side.

Currently I'm using a forked version of sshuttle but I figured someone else might have a similar use case, so I'm submitting this patch: it allows substituting a custom DNS server for those in the SSHed-to-machine's /etc/resolv.conf.

I manually tested using OpenDNS - they have a DNS server at 208.67.222.222 port 53 and 208.67.222.222 port 5353, and https://welcome.opendns.com gives different results based on whether you're using OpenDNS or not.