### PR TITLE
Avoid port forwarding from loopback address

### DIFF
--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -189,8 +189,8 @@ class FreeBsd(Generic):
 
         tables = []
         translating_rules = [
-            b'rdr pass on lo0 %s proto tcp to %s '
-            b'-> %s port %r' % (inet_version, subnet, lo_addr, port)
+            b'rdr pass on lo0 %s proto tcp from ! %s to %s '
+            b'-> %s port %r' % (inet_version, lo_addr, subnet, lo_addr, port)
             for exclude, subnet in includes if not exclude
         ]
         filtering_rules = [

--- a/sshuttle/tests/client/test_methods_pf.py
+++ b/sshuttle/tests/client/test_methods_pf.py
@@ -199,7 +199,7 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         call('-s all'),
         call('-a sshuttle6-1024 -f /dev/stdin',
              b'table <dns_servers> {2404:6800:4004:80c::33}\n'
-             b'rdr pass on lo0 inet6 proto tcp to '
+             b'rdr pass on lo0 inet6 proto tcp from ! ::1 to '
              b'2404:6800:4004:80c::/64 port 8000:9000 -> ::1 port 1024\n'
              b'rdr pass on lo0 inet6 proto udp '
              b'to <dns_servers> port 53 -> ::1 port 1026\n'
@@ -248,7 +248,7 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         call('-s all'),
         call('-a sshuttle-1025 -f /dev/stdin',
              b'table <dns_servers> {1.2.3.33}\n'
-             b'rdr pass on lo0 inet proto tcp to 1.2.3.0/24 '
+             b'rdr pass on lo0 inet proto tcp from ! 127.0.0.1 to 1.2.3.0/24 '
              b'-> 127.0.0.1 port 1025\n'
              b'rdr pass on lo0 inet proto udp '
              b'to <dns_servers> port 53 -> 127.0.0.1 port 1027\n'
@@ -296,8 +296,8 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         call('-s all'),
         call('-a sshuttle6-1024 -f /dev/stdin',
              b'table <dns_servers> {2404:6800:4004:80c::33}\n'
-             b'rdr pass on lo0 inet6 proto tcp to 2404:6800:4004:80c::/64 '
-             b'port 8000:9000 -> ::1 port 1024\n'
+             b'rdr pass on lo0 inet6 proto tcp from ! ::1 to '
+             b'2404:6800:4004:80c::/64 port 8000:9000 -> ::1 port 1024\n'
              b'rdr pass on lo0 inet6 proto udp '
              b'to <dns_servers> port 53 -> ::1 port 1026\n'
              b'pass out quick inet6 proto tcp to '
@@ -343,8 +343,8 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         call('-s all'),
         call('-a sshuttle-1025 -f /dev/stdin',
              b'table <dns_servers> {1.2.3.33}\n'
-             b'rdr pass on lo0 inet proto tcp to 1.2.3.0/24 -> '
-             b'127.0.0.1 port 1025\n'
+             b'rdr pass on lo0 inet proto tcp from ! 127.0.0.1 '
+             b'to 1.2.3.0/24 -> 127.0.0.1 port 1025\n'
              b'rdr pass on lo0 inet proto udp '
              b'to <dns_servers> port 53 -> 127.0.0.1 port 1027\n'
              b'pass out quick inet proto tcp to 1.2.3.66/32 port 80:80\n'


### PR DESCRIPTION
When doing port forwarding on lo0 avoid the special case where the
traffic on lo0 did not came from sshuttle pass out rule but from the lo0
address itself. Fixes #159.