### PR TITLE
Warn about --listen on all addresses (0.0.0.0) and --dns

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -13,7 +13,7 @@ import sys
 import platform
 from sshuttle.ssnet import SockWrapper, Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import log, debug1, debug2, debug3, Fatal, islocal, \
-    resolvconf_nameservers
+    ip_to_int, resolvconf_nameservers
 from sshuttle.methods import get_method, Features
 try:
     from pwd import getpwnam
@@ -693,6 +693,11 @@ def main(listenip_v6, listenip_v4,
 
     bound = False
     if required.dns:
+        if ip_to_int(listenip_v4[0]) == socket.INADDR_ANY:
+            listenip_v4 = ('127.0.0.1', listenip_v4[1])
+            log('WARNING: Requested --listen on all interfaces.\n')
+            log('WARNING: Because of this, --dns will only work locally.\n')
+
         # search for spare port for DNS
         debug2('Binding DNS:')
         ports = range(12300, 9000, -1)

--- a/sshuttle/helpers.py
+++ b/sshuttle/helpers.py
@@ -1,5 +1,6 @@
 import sys
 import socket
+import struct
 import errno
 
 logprefix = ''
@@ -90,6 +91,10 @@ def islocal(ip, family):
     finally:
         sock.close()
     return True  # it's a local IP, or there would have been an error
+
+
+def ip_to_int(ip):
+    return struct.unpack('!I', socket.inet_aton(ip))[0]
 
 
 def family_ip_tuple(ip):

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -13,7 +13,7 @@ import sshuttle.hostwatch as hostwatch
 import subprocess as ssubprocess
 from sshuttle.ssnet import Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import b, log, debug1, debug2, debug3, Fatal, \
-    resolvconf_random_nameserver
+    ip_to_int, resolvconf_random_nameserver
 
 try:
     from shutil import which
@@ -40,7 +40,7 @@ def _ipmatch(ipstr):
             ips += '.0'
             width = min(width, 24)
         ips = ips
-        return (struct.unpack('!I', socket.inet_aton(ips))[0], width)
+        return (ip_to_int(ips), width)
 
 
 def _ipstr(ip, width):


### PR DESCRIPTION
When listening on all addresses (e.g. `--listen 0.0.0.0`) and using `--dns`,
DNS will stop working locally.

This happens because we install a `REDIRECT` rule that sends all outgoing
traffic to port 53 (`--dport`) to the sshuttle udp port on the loopback address.

Later when the response comes back from the server we use that same socket to
send the reply to the original application.

If the socket is bound to loopback, the NAT in iptables that matched earlier
will correctly translate back the source. However if the socket is bound
to all addresses, the response which has as destination the IP from where the
packet would have left the machine, won't be delivered to the application via
loopback but instead via the interface with that address.

Given the above, the iptables rule won't match and the source won't be
translated. The packet is delivered to the application with an unexpected
source and gets dropped.

Unfortunately this change will not solve this problem, but rather detect when
the user requests `--dns` and `--listen` on all interfaces, emit a warning and
make the DNS proxy bind to localhost. In this case DNS will continue to work
locally, however remote machines trying to redirect DNS traffic to sshuttle
won't be able to so anymore, unless `--listen` is provided with a specific IP
address.

I would be happy to implement any other ideas, I just can't think of anything
that would properly resolve this right now.

This is the issue reported in #157.