### PR TITLE
Skip empty lines on incoming routes data

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -489,6 +489,7 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
     def onroutes(routestr):
         if auto_nets:
             for line in routestr.strip().split(b'\n'):
+                if not line: break
                 (family, ip, width) = line.split(b',', 2)
                 family = int(family)
                 width = int(width)

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -489,7 +489,7 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
     def onroutes(routestr):
         if auto_nets:
             for line in routestr.strip().split(b'\n'):
-                if not line: break
+                if not line: continue
                 (family, ip, width) = line.split(b',', 2)
                 family = int(family)
                 width = int(width)


### PR DESCRIPTION
If we receive no routes from server or if, for some reason, we receive
some empty lines, we should skip them instead of crashing.

Fixes one of the problems in #147.