### PR TITLE
Use versions of python3 greater than 3.5 when available (e.g. 3.6)

### DIFF
--- a/run
+++ b/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-set -ex
+set -e
 export PYTHONPATH="$(dirname $0):$PYTHONPATH"
 
 python_best_version() {

--- a/run
+++ b/run
@@ -1,12 +1,11 @@
 #!/usr/bin/env sh
-set -e
+set -ex
 export PYTHONPATH="$(dirname $0):$PYTHONPATH"
 
 python_best_version() {
-  if [ -x "$(command -v python3)" ]; then
-    if python3 -c "import sys; sys.exit(not sys.version_info > (3, 5))"; then
-      exec python3 "$@"
-    fi
+  if [ -x "$(command -v python3)" ] &&
+      python3 -c "import sys; sys.exit(not sys.version_info > (3, 5))"; then
+    exec python3 "$@"
   elif [ -x "$(command -v python2.7)" ]; then
     exec python2.7 "$@"
   else

--- a/run
+++ b/run
@@ -1,11 +1,17 @@
-#!/bin/sh
-source_dir="$(dirname $0)"
-(cd "$source_dir" && "$source_dir/setup.py" --version > /dev/null)
-export PYTHONPATH="$source_dir:$PYTHONPATH"
-if python3.5 -V >/dev/null 2>&1; then
-	exec python3.5 -m "sshuttle" "$@"
-elif python2.7 -V >/dev/null 2>&1; then
-	exec python2.7 -m "sshuttle" "$@"
-else
-	exec python -m "sshuttle" "$@"
-fi
+#!/usr/bin/env sh
+set -e
+export PYTHONPATH="$(dirname $0):$PYTHONPATH"
+
+python_best_version() {
+  if [ -x "$(command -v python3)" ]; then
+    if python3 -c "import sys; sys.exit(not sys.version_info > (3, 5))"; then
+      exec python3 "$@"
+    fi
+  elif [ -x "$(command -v python2.7)" ]; then
+    exec python2.7 "$@"
+  else
+    exec python "$@"
+  fi
+}
+
+python_best_version -m "sshuttle" "$@"

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -116,7 +116,7 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
         if python:
             pycmd = "'%s' -c '%s'" % (python, pyscript)
         else:
-            pycmd = ("P=python3.5; $P -V 2>/dev/null || P=python; "
+            pycmd = ("P=python3; $P -V 2>/dev/null || P=python; "
                      "exec \"$P\" -c %s") % quote(pyscript)
             pycmd = ("exec /bin/sh -c %s" % quote(pycmd))
         argv = (sshl +


### PR DESCRIPTION
Some Linux distros, like Alpine, Arch, etc and some BSDs, like FreeBSD, are
now shipping with python3.6 as the default python3. Both the client and the
server are failing to run in this distros, because we are specifically looking
for python3.5.

These changes make the run shell script use python3 if the version is greater
than 3.5, otherwise falling back as usual.

On the server any version of python3 will do, use it before falling back to
python, as the server code can run with any version of python3.