### PR TITLE
Fixes UDP and DNS proxies binding to the same socket address

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -684,6 +684,7 @@ def main(listenip_v6, listenip_v4,
         except socket.error as e:
             if e.errno == errno.EADDRINUSE:
                 last_e = e
+                used_ports.append(port)
             else:
                 raise e
 
@@ -724,10 +725,12 @@ def main(listenip_v6, listenip_v4,
             try:
                 dns_listener.bind(lv6, lv4)
                 bound = True
+                used_ports.append(port)
                 break
             except socket.error as e:
                 if e.errno == errno.EADDRINUSE:
                     last_e = e
+                    used_ports.append(port)
                 else:
                     raise e
         debug2('\n')

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -389,7 +389,7 @@ def onaccept_udp(listener, method, mux, handlers):
     srcip, dstip, data = t
     debug1('Accept UDP: %r -> %r.\n' % (srcip, dstip,))
     if srcip in udp_by_src:
-        chan, timeout = udp_by_src[srcip]
+        chan, _ = udp_by_src[srcip]
     else:
         chan = mux.next_channel()
         mux.channels[chan] = lambda cmd, data: udp_done(

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -635,6 +635,9 @@ def main(listenip_v6, listenip_v4,
     else:
         # if at least one port missing, we have to search
         ports = range(12300, 9000, -1)
+        # keep track of failed bindings and used ports to avoid trying to
+        # bind to the same socket address twice in different listeners
+        used_ports = []
 
     # search for free ports and try to bind
     last_e = None
@@ -676,6 +679,7 @@ def main(listenip_v6, listenip_v4,
             if udp_listener:
                 udp_listener.bind(lv6, lv4)
             bound = True
+            used_ports.append(port)
             break
         except socket.error as e:
             if e.errno == errno.EADDRINUSE:
@@ -699,6 +703,8 @@ def main(listenip_v6, listenip_v4,
         ports = range(12300, 9000, -1)
         for port in ports:
             debug2(' %d' % port)
+            if port in used_ports: continue
+
             dns_listener = MultiListener(socket.SOCK_DGRAM)
 
             if listenip_v6:

--- a/sshuttle/tests/client/test_helpers.py
+++ b/sshuttle/tests/client/test_helpers.py
@@ -2,6 +2,7 @@ from mock import patch, call
 import sys
 import io
 import socket
+import errno
 
 import sshuttle.helpers
 
@@ -162,7 +163,11 @@ nameserver 2404:6800:4004:80c::4
     ]
 
 
-def test_islocal():
+@patch('sshuttle.helpers.socket.socket.bind')
+def test_islocal(mock_bind):
+    bind_error = socket.error(errno.EADDRNOTAVAIL)
+    mock_bind.side_effect = [None, bind_error, None, bind_error]
+
     assert sshuttle.helpers.islocal("127.0.0.1", socket.AF_INET)
     assert not sshuttle.helpers.islocal("192.0.2.1", socket.AF_INET)
     assert sshuttle.helpers.islocal("::1", socket.AF_INET6)


### PR DESCRIPTION
As suggested by @colinmkeith the UDP and DNS proxies should listen on different
ports otherwise the DNS proxy can get traffic intended to the UDP proxy (or
vice-versa) and handle it incorrectly as reported in #178.

At first sight it seems that we had the code in place to try another port if
the one we are binding is already bound, however, with UDP and REUSEADDR the
OS will not refuse to bind two sockets to the same socket address, so both
the UDP proxy and DNS proxy were being bound to the same pair.