### PR TITLE
Some style fixes following pylint's advice

### DIFF
--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -25,7 +25,7 @@ def main():
                 parser.error('exactly zero arguments expected')
             return firewall.main(opt.method, opt.syslog)
         elif opt.hostwatch:
-            return hostwatch.hw_main(opt.subnets)
+            return hostwatch.hw_main(opt.subnets, opt.auto_hosts)
         else:
             includes = opt.subnets + opt.subnets_file
             excludes = opt.exclude

--- a/sshuttle/methods/__init__.py
+++ b/sshuttle/methods/__init__.py
@@ -35,7 +35,8 @@ class BaseMethod(object):
     def set_firewall(self, firewall):
         self.firewall = firewall
 
-    def get_supported_features(self):
+    @staticmethod
+    def get_supported_features():
         result = Features()
         result.ipv6 = False
         result.udp = False
@@ -43,10 +44,12 @@ class BaseMethod(object):
         result.user = False
         return result
 
-    def get_tcp_dstip(self, sock):
+    @staticmethod
+    def get_tcp_dstip(sock):
         return original_dst(sock)
 
-    def recv_udp(self, udp_listener, bufsize):
+    @staticmethod
+    def recv_udp(udp_listener, bufsize):
         debug3('Accept UDP using recvfrom.\n')
         data, srcip = udp_listener.recvfrom(bufsize)
         return (srcip, None, data)
@@ -77,7 +80,8 @@ class BaseMethod(object):
     def restore_firewall(self, port, family, udp, user):
         raise NotImplementedError()
 
-    def firewall_command(self, line):
+    @staticmethod
+    def firewall_command(line):
         return False
 
 

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -150,17 +150,17 @@ def ipfw_noexit(*args):
     ssubprocess.call(argv)
 
 class Method(BaseMethod):
-    
+
     def get_supported_features(self):
         result = super(Method, self).get_supported_features()
         result.ipv6 = False
         result.udp = False #NOTE: Almost there, kernel patch needed
         result.dns = True
         return result
-    
+
     def get_tcp_dstip(self, sock):
         return sock.getsockname()
-    
+
     def recv_udp(self, udp_listener, bufsize):
         srcip, dstip, data = recv_udp(udp_listener, bufsize)
         if not dstip:
@@ -199,7 +199,7 @@ class Method(BaseMethod):
             raise Exception(
                 'Address family "%s" unsupported by ipfw method_name'
                 % family_to_string(family))
-    
+
         #XXX: Any risk from this?
         ipfw_noexit('delete', '1')
 
@@ -207,13 +207,13 @@ class Method(BaseMethod):
             name = _changedctls.pop()
             oldval = _oldctls[name]
             _sysctl_set(name, oldval)
-    
+
         if subnets or dnsport:
             sysctl_set('net.inet.ip.fw.enable', 1)
-            
+
         ipfw('add', '1', 'check-state', 'ip',
              'from', 'any', 'to', 'any')
-        
+
         ipfw('add', '1', 'skipto', '2',
              'tcp',
              'from', 'any', 'to', 'table(125)')

--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -35,11 +35,11 @@ class Generic(object):
 
     class pf_addr(Structure):
         class _pfa(Union):
-             _fields_ = [("v4", c_uint32),     # struct in_addr
-                        ("v6", c_uint32 * 4),  # struct in6_addr
-                        ("addr8", c_uint8 * 16),
-                        ("addr16", c_uint16 * 8),
-                        ("addr32", c_uint32 * 4)]
+            _fields_ = [("v4", c_uint32),     # struct in_addr
+                       ("v6", c_uint32 * 4),  # struct in6_addr
+                       ("addr8", c_uint8 * 16),
+                       ("addr16", c_uint16 * 8),
+                       ("addr32", c_uint32 * 4)]
 
         _fields_ = [("pfa", _pfa)]
         _anonymous_ = ("pfa",)
@@ -66,7 +66,8 @@ class Generic(object):
             pfctl('-e')
             _pf_context['started_by_sshuttle'] += 1
 
-    def disable(self, anchor):
+    @staticmethod
+    def disable(anchor):
         pfctl('-a %s -F all' % anchor)
         if _pf_context['started_by_sshuttle'] == 1:
             pfctl('-d')
@@ -98,11 +99,13 @@ class Generic(object):
         port = socket.ntohs(self._get_natlook_port(pnl.rdxport))
         return (ip, port)
 
-    def _add_natlook_ports(self, pnl, src_port, dst_port):
+    @staticmethod
+    def _add_natlook_ports(pnl, src_port, dst_port):
         pnl.sxport = socket.htons(src_port)
         pnl.dxport = socket.htons(dst_port)
 
-    def _get_natlook_port(self, xport):
+    @staticmethod
+    def _get_natlook_port(xport):
         return xport
 
     def add_anchors(self, anchor, status=None):
@@ -129,18 +132,22 @@ class Generic(object):
             'I', self.PF_CHANGE_ADD_TAIL), 4)  # action = PF_CHANGE_ADD_TAIL
         ioctl(pf_get_dev(), pf.DIOCCHANGERULE, pr)
 
-    def _inet_version(self, family):
+    @staticmethod
+    def _inet_version(family):
         return b'inet' if family == socket.AF_INET else b'inet6'
 
-    def _lo_addr(self, family):
+    @staticmethod
+    def _lo_addr(family):
         return b'127.0.0.1' if family == socket.AF_INET else b'::1'
 
-    def add_rules(self, anchor, rules):
+    @staticmethod
+    def add_rules(anchor, rules):
         assert isinstance(rules, bytes)
         debug3("rules:\n" + rules.decode("ASCII"))
         pfctl('-a %s -f /dev/stdin' % anchor, rules)
 
-    def has_skip_loopback(self):
+    @staticmethod
+    def has_skip_loopback():
         return b'skip' in pfctl('-s Interfaces -i lo -v')[0]
 
 

--- a/sshuttle/sdnotify.py
+++ b/sshuttle/sdnotify.py
@@ -9,7 +9,7 @@ def _notify(message):
         return False
 
     addr = '\0' + addr[1:] if addr[0] == '@' else addr
-    
+
     try:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
     except (OSError, IOError) as e:

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -175,7 +175,8 @@ class DnsProxy(Handler):
             self.to_nameserver = self._addrinfo(peer, port)
         self.try_send()
 
-    def _addrinfo(self, peer, port):
+    @staticmethod
+    def _addrinfo(peer, port):
         if int(port) == 0:
             port = 53
         family, _, _, _, sockaddr = socket.getaddrinfo(peer, port)[0]

--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -200,7 +200,8 @@ class SockWrapper:
                 _, e = sys.exc_info()[:2]
                 self.seterr('nowrite: %s' % e)
 
-    def too_full(self):
+    @staticmethod
+    def too_full():
         return False  # fullness is determined by the socket's select() state
 
     def uwrite(self, buf):

--- a/sshuttle/tests/client/test_firewall.py
+++ b/sshuttle/tests/client/test_firewall.py
@@ -84,7 +84,7 @@ def test_subnet_weight():
         (socket.AF_INET, 16, 0, '192.168.0.0', 0, 0),
         (socket.AF_INET, 0, 1, '0.0.0.0', 0, 0)
     ]
-    
+
     assert subnets_sorted == \
             sorted(subnets, key=sshuttle.firewall.subnet_weight, reverse=True)
 

--- a/sshuttle/tests/client/test_methods_pf.py
+++ b/sshuttle/tests/client/test_methods_pf.py
@@ -424,7 +424,7 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     mock_pf_get_dev.reset_mock()
     mock_ioctl.reset_mock()
     mock_pfctl.reset_mock()
-    
+
     with pytest.raises(Exception) as excinfo:
         method.setup_firewall(
             1025, 1027,

--- a/sshuttle/tests/client/test_methods_tproxy.py
+++ b/sshuttle/tests/client/test_methods_tproxy.py
@@ -241,7 +241,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt_ttl, mock_ipt):
              '--tproxy-mark', '0x1/0x1', '--dest', u'1.2.3.33/32',
              '-m', 'udp', '-p', 'udp', '--dport', '53', '--on-port', '1027'),
         call(2, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'RETURN',
-             '--dest', u'1.2.3.66/32', '-m', 'tcp', '-p', 'tcp', 
+             '--dest', u'1.2.3.66/32', '-m', 'tcp', '-p', 'tcp',
              '--dport', '80:80'),
         call(2, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'RETURN',
              '--dest', u'1.2.3.66/32', '-m', 'tcp', '-p', 'tcp',


### PR DESCRIPTION
These include removing trailing whitespaces, turnings methods that do not reference self into static methods and an argument missing in hw_main call.

@brianmay I tried to divide them in different commits, if you don't like some of these we can drop the corresponding commit.

In the future it would be nice to have some agreed pylint configuration in the repo and use some automated service to mark the PRs as good or not good like travis does for tests. [Codacy](https://www.codacy.com) is free for open source projects.