### PR TITLE
Linters initial config

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,3 @@
+[bandit]
+exclude: sshuttle/tests
+skips: B101,B104,B404,B603,B606,B607

--- a/.prospector.yml
+++ b/.prospector.yml
@@ -1,0 +1,19 @@
+strictness: medium
+
+pylint:
+  disable:
+    - too-many-statements
+    - too-many-locals
+    - too-many-function-args
+    - too-many-arguments
+    - too-many-branches
+    - bare-except
+    - protected-access
+    - no-else-return
+
+pep8:
+  options:
+    max-line-length: 79
+
+mccabe:
+  run: false

--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -21,7 +21,7 @@ while 1:
             setattr(sys.modules[parent], parent_name, module)
 
         code = compile(content, name, "exec")
-        exec(code, module.__dict__)
+        exec(code, module.__dict__) # nosec
         sys.modules[name] = module
     else:
         break


### PR DESCRIPTION
# Initial configuration for Bandit and Prospector
With this configuration it should be feasible to achieve a perfect score
without much contortion.

## Rules skipped for Bandit
- B101: assert_used
- B104: hardcoded_bind_all_interfaces
- B404: import_subprocess
- B603: subprocess_without_shell_equals_true
- B606: start_process_with_no_shell
- B607: start_process_with_partial_path

## Rules skipped for pylint
- too-many-statements
- too-many-locals
- too-many-function-args
- too-many-arguments
- too-many-branches
- bare-except
- protected-access
- no-else-return