### PR TITLE
Properly decode seed hosts argument in server.py

### DIFF
--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -326,7 +326,7 @@ def main(latency_control, auto_hosts, to_nameserver):
     def got_host_req(data):
         if not hw.pid:
             (hw.pid, hw.sock) = start_hostwatch(
-                    data.strip().split(), auto_hosts)
+                    data.decode("ASCII").strip().split(), auto_hosts)
             handlers.append(Handler(socks=[hw.sock],
                                     callback=hostwatch_ready))
     mux.got_host_req = got_host_req


### PR DESCRIPTION
When I starting sshuttle with option `--seed-hosts example.domain.local`, got the following error:

```
hostwatch: Starting hostwatch with Python version 3.5.2
hostwatch: Traceback (most recent call last):
--->   File "sshuttle.server", line 144, in start_hostwatch
--->   File "sshuttle.hostwatch", line 272, in hw_main
--->   File "sshuttle.hostwatch", line 234, in check_host
--->   File "sshuttle.hostwatch", line 32, in _is_ip
--->   File "/usr/lib/python3.5/re.py", line 163, in match
--->     return _compile(pattern, flags).match(string)
---> TypeError: cannot use a string pattern on a bytes-like object
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "assembler.py", line 37, in <module>
  File "sshuttle.server", line 393, in main
  File "sshuttle.ssnet", line 596, in runonce
  File "sshuttle.server", line 324, in hostwatch_ready
sshuttle.helpers.Fatal: hostwatch process died
```

It seems like the list of hosts is not properly decoded on the server side. This is an attempt to fix that.