### PR TITLE
move sdnotify after setting up firewall rules

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -8,7 +8,6 @@ import os
 import sshuttle.ssnet as ssnet
 import sshuttle.ssh as ssh
 import sshuttle.ssyslog as ssyslog
-import sshuttle.sdnotify as sdnotify
 import sys
 import platform
 from sshuttle.ssnet import SockWrapper, Handler, Proxy, Mux, MuxWrapper
@@ -532,9 +531,6 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
     if seed_hosts is not None:
         debug1('seed_hosts: %r\n' % seed_hosts)
         mux.send(0, ssnet.CMD_HOST_REQ, str.encode('\n'.join(seed_hosts)))
-
-    sdnotify.send(sdnotify.ready(),
-                  sdnotify.status('Connected to %s.' % remotename))
 
     while 1:
         rv = serverproc.poll()

--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -7,7 +7,6 @@ import sys
 import os
 import platform
 import traceback
-import sshuttle.sdnotify as sdnotify
 from sshuttle.helpers import debug1, debug2, Fatal
 from sshuttle.methods import get_auto_method, get_method
 

--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -7,6 +7,7 @@ import sys
 import os
 import platform
 import traceback
+import sshuttle.sdnotify as sdnotify
 from sshuttle.helpers import debug1, debug2, Fatal
 from sshuttle.methods import get_auto_method, get_method
 
@@ -219,6 +220,8 @@ def main(method_name, syslog):
                 user)
 
         stdout.write('STARTED\n')
+        sdnotify.send(sdnotify.ready(),
+                  sdnotify.status('Connected'))
 
         try:
             stdout.flush()


### PR DESCRIPTION
Moved sdnotify to be sent to systemd after the firewall rules have been set up.

With the original code the notify was sent before the tunnel was actually usable, resulting in dependent systemd units to not start up correctly (as systemd starts to fire them off as soon as it receives the notify). Note that I have just moved this to what seemed to be a good point based on the logs, I have not in detail looked into how things are threaded / forked / whatevered.