### PR TITLE
Fix tests on Macos

### DIFF
--- a/sshuttle/tests/client/test_helpers.py
+++ b/sshuttle/tests/client/test_helpers.py
@@ -2,6 +2,7 @@ from mock import patch, call
 import sys
 import io
 import socket
+from socket import AF_INET, AF_INET6
 import errno
 
 import sshuttle.helpers
@@ -133,10 +134,12 @@ nameserver 2404:6800:4004:80c::4
 
     ns = sshuttle.helpers.resolvconf_nameservers()
     assert ns == [
-        (2, u'192.168.1.1'), (2, u'192.168.2.1'),
-        (2, u'192.168.3.1'), (2, u'192.168.4.1'),
-        (10, u'2404:6800:4004:80c::1'), (10, u'2404:6800:4004:80c::2'),
-        (10, u'2404:6800:4004:80c::3'), (10, u'2404:6800:4004:80c::4')
+        (AF_INET, u'192.168.1.1'), (AF_INET, u'192.168.2.1'),
+        (AF_INET, u'192.168.3.1'), (AF_INET, u'192.168.4.1'),
+        (AF_INET6, u'2404:6800:4004:80c::1'),
+        (AF_INET6, u'2404:6800:4004:80c::2'),
+        (AF_INET6, u'2404:6800:4004:80c::3'),
+        (AF_INET6, u'2404:6800:4004:80c::4')
     ]
 
 
@@ -156,10 +159,12 @@ nameserver 2404:6800:4004:80c::4
 """)
     ns = sshuttle.helpers.resolvconf_random_nameserver()
     assert ns in [
-        (2, u'192.168.1.1'), (2, u'192.168.2.1'),
-        (2, u'192.168.3.1'), (2, u'192.168.4.1'),
-        (10, u'2404:6800:4004:80c::1'), (10, u'2404:6800:4004:80c::2'),
-        (10, u'2404:6800:4004:80c::3'), (10, u'2404:6800:4004:80c::4')
+        (AF_INET, u'192.168.1.1'), (AF_INET, u'192.168.2.1'),
+        (AF_INET, u'192.168.3.1'), (AF_INET, u'192.168.4.1'),
+        (AF_INET6, u'2404:6800:4004:80c::1'),
+        (AF_INET6, u'2404:6800:4004:80c::2'),
+        (AF_INET6, u'2404:6800:4004:80c::3'),
+        (AF_INET6, u'2404:6800:4004:80c::4')
     ]
 
 
@@ -168,26 +173,26 @@ def test_islocal(mock_bind):
     bind_error = socket.error(errno.EADDRNOTAVAIL)
     mock_bind.side_effect = [None, bind_error, None, bind_error]
 
-    assert sshuttle.helpers.islocal("127.0.0.1", socket.AF_INET)
-    assert not sshuttle.helpers.islocal("192.0.2.1", socket.AF_INET)
-    assert sshuttle.helpers.islocal("::1", socket.AF_INET6)
-    assert not sshuttle.helpers.islocal("2001:db8::1", socket.AF_INET6)
+    assert sshuttle.helpers.islocal("127.0.0.1", AF_INET)
+    assert not sshuttle.helpers.islocal("192.0.2.1", AF_INET)
+    assert sshuttle.helpers.islocal("::1", AF_INET6)
+    assert not sshuttle.helpers.islocal("2001:db8::1", AF_INET6)
 
 
 def test_family_ip_tuple():
     assert sshuttle.helpers.family_ip_tuple("127.0.0.1") \
-        == (socket.AF_INET, "127.0.0.1")
+        == (AF_INET, "127.0.0.1")
     assert sshuttle.helpers.family_ip_tuple("192.168.2.6") \
-        == (socket.AF_INET, "192.168.2.6")
+        == (AF_INET, "192.168.2.6")
     assert sshuttle.helpers.family_ip_tuple("::1") \
-        == (socket.AF_INET6, "::1")
+        == (AF_INET6, "::1")
     assert sshuttle.helpers.family_ip_tuple("2404:6800:4004:80c::1") \
-        == (socket.AF_INET6, "2404:6800:4004:80c::1")
+        == (AF_INET6, "2404:6800:4004:80c::1")
 
 
 def test_family_to_string():
-    assert sshuttle.helpers.family_to_string(socket.AF_INET) == "AF_INET"
-    assert sshuttle.helpers.family_to_string(socket.AF_INET6) == "AF_INET6"
+    assert sshuttle.helpers.family_to_string(AF_INET) == "AF_INET"
+    assert sshuttle.helpers.family_to_string(AF_INET6) == "AF_INET6"
     if sys.version_info < (3, 0):
         expected = "1"
         assert sshuttle.helpers.family_to_string(socket.AF_UNIX) == "1"

--- a/sshuttle/tests/client/test_methods_nat.py
+++ b/sshuttle/tests/client/test_methods_nat.py
@@ -1,6 +1,7 @@
 import pytest
 from mock import Mock, patch, call
 import socket
+from socket import AF_INET, AF_INET6
 import struct
 
 from sshuttle.helpers import Fatal
@@ -18,7 +19,7 @@ def test_get_supported_features():
 def test_get_tcp_dstip():
     sock = Mock()
     sock.getsockopt.return_value = struct.pack(
-        '!HHBBBB', socket.ntohs(socket.AF_INET), 1024, 127, 0, 0, 1)
+        '!HHBBBB', socket.ntohs(AF_INET), 1024, 127, 0, 0, 1)
     method = get_method('nat')
     assert method.get_tcp_dstip(sock) == ('127.0.0.1', 1024)
     assert sock.mock_calls == [call.getsockopt(0, 80, 16)]
@@ -84,10 +85,10 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt_ttl, mock_ipt):
     with pytest.raises(Exception) as excinfo:
         method.setup_firewall(
             1024, 1026,
-            [(10, u'2404:6800:4004:80c::33')],
-            10,
-            [(10, 64, False, u'2404:6800:4004:80c::', 0, 0),
-                (10, 128, True, u'2404:6800:4004:80c::101f', 80, 80)],
+            [(AF_INET6, u'2404:6800:4004:80c::33')],
+            AF_INET6,
+            [(AF_INET6, 64, False, u'2404:6800:4004:80c::', 0, 0),
+                (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 80, 80)],
             True,
             None)
     assert str(excinfo.value) \
@@ -99,10 +100,10 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt_ttl, mock_ipt):
     with pytest.raises(Exception) as excinfo:
         method.setup_firewall(
             1025, 1027,
-            [(2, u'1.2.3.33')],
-            2,
-            [(2, 24, False, u'1.2.3.0', 8000, 9000),
-                (2, 32, True, u'1.2.3.66', 8080, 8080)],
+            [(AF_INET, u'1.2.3.33')],
+            AF_INET,
+            [(AF_INET, 24, False, u'1.2.3.0', 8000, 9000),
+                (AF_INET, 32, True, u'1.2.3.66', 8080, 8080)],
             True,
             None)
     assert str(excinfo.value) == 'UDP not supported by nat method_name'
@@ -112,49 +113,49 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt_ttl, mock_ipt):
 
     method.setup_firewall(
         1025, 1027,
-        [(2, u'1.2.3.33')],
-        2,
-        [(2, 24, False, u'1.2.3.0', 8000, 9000),
-            (2, 32, True, u'1.2.3.66', 8080, 8080)],
+        [(AF_INET, u'1.2.3.33')],
+        AF_INET,
+        [(AF_INET, 24, False, u'1.2.3.0', 8000, 9000),
+            (AF_INET, 32, True, u'1.2.3.66', 8080, 8080)],
         False,
         None)
     assert mock_ipt_chain_exists.mock_calls == [
-        call(2, 'nat', 'sshuttle-1025')
+        call(AF_INET, 'nat', 'sshuttle-1025')
     ]
     assert mock_ipt_ttl.mock_calls == [
-        call(2, 'nat', '-A', 'sshuttle-1025', '-j', 'REDIRECT',
+        call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'REDIRECT',
             '--dest', u'1.2.3.0/24', '-p', 'tcp', '--dport', '8000:9000',
              '--to-ports', '1025'),
-        call(2, 'nat', '-A', 'sshuttle-1025', '-j', 'REDIRECT',
+        call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'REDIRECT',
              '--dest', u'1.2.3.33/32', '-p', 'udp',
              '--dport', '53', '--to-ports', '1027')
     ]
     assert mock_ipt.mock_calls == [
-        call(2, 'nat', '-D', 'OUTPUT', '-j', 'sshuttle-1025'),
-        call(2, 'nat', '-D', 'PREROUTING', '-j', 'sshuttle-1025'),
-        call(2, 'nat', '-F', 'sshuttle-1025'),
-        call(2, 'nat', '-X', 'sshuttle-1025'),
-        call(2, 'nat', '-N', 'sshuttle-1025'),
-        call(2, 'nat', '-F', 'sshuttle-1025'),
-        call(2, 'nat', '-I', 'OUTPUT', '1', '-j', 'sshuttle-1025'),
-        call(2, 'nat', '-I', 'PREROUTING', '1', '-j', 'sshuttle-1025'),
-        call(2, 'nat', '-A', 'sshuttle-1025', '-j', 'RETURN',
+        call(AF_INET, 'nat', '-D', 'OUTPUT', '-j', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-D', 'PREROUTING', '-j', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-F', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-X', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-N', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-F', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-I', 'OUTPUT', '1', '-j', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-I', 'PREROUTING', '1', '-j', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'RETURN',
             '--dest', u'1.2.3.66/32', '-p', 'tcp', '--dport', '8080:8080')
     ]
     mock_ipt_chain_exists.reset_mock()
     mock_ipt_ttl.reset_mock()
     mock_ipt.reset_mock()
 
-    method.restore_firewall(1025, 2, False, None)
+    method.restore_firewall(1025, AF_INET, False, None)
     assert mock_ipt_chain_exists.mock_calls == [
-        call(2, 'nat', 'sshuttle-1025')
+        call(AF_INET, 'nat', 'sshuttle-1025')
     ]
     assert mock_ipt_ttl.mock_calls == []
     assert mock_ipt.mock_calls == [
-        call(2, 'nat', '-D', 'OUTPUT', '-j', 'sshuttle-1025'),
-        call(2, 'nat', '-D', 'PREROUTING', '-j', 'sshuttle-1025'),
-        call(2, 'nat', '-F', 'sshuttle-1025'),
-        call(2, 'nat', '-X', 'sshuttle-1025')
+        call(AF_INET, 'nat', '-D', 'OUTPUT', '-j', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-D', 'PREROUTING', '-j', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-F', 'sshuttle-1025'),
+        call(AF_INET, 'nat', '-X', 'sshuttle-1025')
     ]
     mock_ipt_chain_exists.reset_mock()
     mock_ipt_ttl.reset_mock()

--- a/sshuttle/tests/client/test_methods_pf.py
+++ b/sshuttle/tests/client/test_methods_pf.py
@@ -1,6 +1,7 @@
 import pytest
 from mock import Mock, patch, call, ANY
 import socket
+from socket import AF_INET, AF_INET6
 
 from sshuttle.methods import get_method
 from sshuttle.helpers import Fatal
@@ -20,7 +21,7 @@ def test_get_tcp_dstip():
     sock = Mock()
     sock.getpeername.return_value = ("127.0.0.1", 1024)
     sock.getsockname.return_value = ("127.0.0.2", 1025)
-    sock.family = socket.AF_INET
+    sock.family = AF_INET
 
     firewall = Mock()
     firewall.pfile.readline.return_value = \
@@ -94,7 +95,7 @@ def test_firewall_command_darwin(mock_pf_get_dev, mock_ioctl, mock_stdout):
     assert not method.firewall_command("somthing")
 
     command = "QUERY_PF_NAT %d,%d,%s,%d,%s,%d\n" % (
-        socket.AF_INET, socket.IPPROTO_TCP,
+        AF_INET, socket.IPPROTO_TCP,
         "127.0.0.1", 1025, "127.0.0.2", 1024)
     assert method.firewall_command(command)
 
@@ -117,7 +118,7 @@ def test_firewall_command_freebsd(mock_pf_get_dev, mock_ioctl, mock_stdout):
     assert not method.firewall_command("somthing")
 
     command = "QUERY_PF_NAT %d,%d,%s,%d,%s,%d\n" % (
-        socket.AF_INET, socket.IPPROTO_TCP,
+        AF_INET, socket.IPPROTO_TCP,
         "127.0.0.1", 1025, "127.0.0.2", 1024)
     assert method.firewall_command(command)
 
@@ -140,7 +141,7 @@ def test_firewall_command_openbsd(mock_pf_get_dev, mock_ioctl, mock_stdout):
     assert not method.firewall_command("somthing")
 
     command = "QUERY_PF_NAT %d,%d,%s,%d,%s,%d\n" % (
-        socket.AF_INET, socket.IPPROTO_TCP,
+        AF_INET, socket.IPPROTO_TCP,
         "127.0.0.1", 1025, "127.0.0.2", 1024)
     assert method.firewall_command(command)
 
@@ -180,10 +181,10 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
 
     method.setup_firewall(
         1024, 1026,
-        [(10, u'2404:6800:4004:80c::33')],
-        10,
-        [(10, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
-            (10, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
+        [(AF_INET6, u'2404:6800:4004:80c::33')],
+        AF_INET6,
+        [(AF_INET6, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
+            (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
         False,
         None)
     assert mock_ioctl.mock_calls == [
@@ -219,10 +220,10 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     with pytest.raises(Exception) as excinfo:
         method.setup_firewall(
             1025, 1027,
-            [(2, u'1.2.3.33')],
-            2,
-            [(2, 24, False, u'1.2.3.0', 0, 0),
-                (2, 32, True, u'1.2.3.66', 80, 80)],
+            [(AF_INET, u'1.2.3.33')],
+            AF_INET,
+            [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
+                (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
             True,
             None)
     assert str(excinfo.value) == 'UDP not supported by pf method_name'
@@ -232,9 +233,10 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
 
     method.setup_firewall(
         1025, 1027,
-        [(2, u'1.2.3.33')],
-        2,
-        [(2, 24, False, u'1.2.3.0', 0, 0), (2, 32, True, u'1.2.3.66', 80, 80)],
+        [(AF_INET, u'1.2.3.33')],
+        AF_INET,
+        [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
+            (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
         False,
         None)
     assert mock_ioctl.mock_calls == [
@@ -265,7 +267,7 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     mock_ioctl.reset_mock()
     mock_pfctl.reset_mock()
 
-    method.restore_firewall(1025, 2, False, None)
+    method.restore_firewall(1025, AF_INET, False, None)
     assert mock_ioctl.mock_calls == []
     assert mock_pfctl.mock_calls == [
         call('-a sshuttle-1025 -F all'),
@@ -291,10 +293,10 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl,
 
     method.setup_firewall(
         1024, 1026,
-        [(10, u'2404:6800:4004:80c::33')],
-        10,
-        [(10, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
-            (10, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
+        [(AF_INET6, u'2404:6800:4004:80c::33')],
+        AF_INET6,
+        [(AF_INET6, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
+            (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
         False,
         None)
 
@@ -322,10 +324,10 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl,
     with pytest.raises(Exception) as excinfo:
         method.setup_firewall(
             1025, 1027,
-            [(2, u'1.2.3.33')],
-            2,
-            [(2, 24, False, u'1.2.3.0', 0, 0),
-                (2, 32, True, u'1.2.3.66', 80, 80)],
+            [(AF_INET, u'1.2.3.33')],
+            AF_INET,
+            [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
+                (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
             True,
             None)
     assert str(excinfo.value) == 'UDP not supported by pf method_name'
@@ -335,9 +337,10 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl,
 
     method.setup_firewall(
         1025, 1027,
-        [(2, u'1.2.3.33')],
-        2,
-        [(2, 24, False, u'1.2.3.0', 0, 0), (2, 32, True, u'1.2.3.66', 80, 80)],
+        [(AF_INET, u'1.2.3.33')],
+        AF_INET,
+        [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
+            (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
         False,
         None)
     assert mock_ioctl.mock_calls == [
@@ -366,8 +369,8 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl,
     mock_ioctl.reset_mock()
     mock_pfctl.reset_mock()
 
-    method.restore_firewall(1025, 2, False, None)
-    method.restore_firewall(1024, 10, False, None)
+    method.restore_firewall(1025, AF_INET, False, None)
+    method.restore_firewall(1024, AF_INET6, False, None)
     assert mock_ioctl.mock_calls == []
     assert mock_pfctl.mock_calls == [
         call('-a sshuttle-1025 -F all'),
@@ -392,10 +395,10 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
 
     method.setup_firewall(
         1024, 1026,
-        [(10, u'2404:6800:4004:80c::33')],
-        10,
-        [(10, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
-            (10, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
+        [(AF_INET6, u'2404:6800:4004:80c::33')],
+        AF_INET6,
+        [(AF_INET6, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
+            (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
         False,
         None)
 
@@ -428,10 +431,10 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     with pytest.raises(Exception) as excinfo:
         method.setup_firewall(
             1025, 1027,
-            [(2, u'1.2.3.33')],
-            2,
-            [(2, 24, False, u'1.2.3.0', 0, 0),
-                (2, 32, True, u'1.2.3.66', 80, 80)],
+            [(AF_INET, u'1.2.3.33')],
+            AF_INET,
+            [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
+                (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
             True,
             None)
     assert str(excinfo.value) == 'UDP not supported by pf method_name'
@@ -441,10 +444,10 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
 
     method.setup_firewall(
         1025, 1027,
-        [(2, u'1.2.3.33')],
-        2,
-        [(2, 24, False, u'1.2.3.0', 0, 0),
-            (2, 32, True, u'1.2.3.66', 80, 80)],
+        [(AF_INET, u'1.2.3.33')],
+        AF_INET,
+        [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
+            (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
         False,
         None)
     assert mock_ioctl.mock_calls == [
@@ -471,8 +474,8 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     mock_ioctl.reset_mock()
     mock_pfctl.reset_mock()
 
-    method.restore_firewall(1025, 2, False, None)
-    method.restore_firewall(1024, 10, False, None)
+    method.restore_firewall(1025, AF_INET, False, None)
+    method.restore_firewall(1024, AF_INET6, False, None)
     assert mock_ioctl.mock_calls == []
     assert mock_pfctl.mock_calls == [
         call('-a sshuttle-1025 -F all'),

--- a/sshuttle/tests/client/test_methods_tproxy.py
+++ b/sshuttle/tests/client/test_methods_tproxy.py
@@ -1,3 +1,6 @@
+import socket
+from socket import AF_INET, AF_INET6
+
 from mock import Mock, patch, call
 
 from sshuttle.methods import get_method
@@ -49,7 +52,7 @@ def test_send_udp(mock_socket):
     assert sock.mock_calls == []
     assert mock_socket.mock_calls == [
         call(sock.family, 2),
-        call().setsockopt(1, 2, 1),
+        call().setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1),
         call().setsockopt(0, 19, 1),
         call().bind('127.0.0.2'),
         call().sendto("2222222", '127.0.0.1'),
@@ -100,72 +103,73 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt_ttl, mock_ipt):
 
     method.setup_firewall(
         1024, 1026,
-        [(10, u'2404:6800:4004:80c::33')],
-        10,
-        [(10, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
-            (10, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
+        [(AF_INET6, u'2404:6800:4004:80c::33')],
+        AF_INET6,
+        [(AF_INET6, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
+            (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
         True,
         None)
     assert mock_ipt_chain_exists.mock_calls == [
-        call(10, 'mangle', 'sshuttle-m-1024'),
-        call(10, 'mangle', 'sshuttle-t-1024'),
-        call(10, 'mangle', 'sshuttle-d-1024')
+        call(AF_INET6, 'mangle', 'sshuttle-m-1024'),
+        call(AF_INET6, 'mangle', 'sshuttle-t-1024'),
+        call(AF_INET6, 'mangle', 'sshuttle-d-1024')
     ]
     assert mock_ipt_ttl.mock_calls == []
     assert mock_ipt.mock_calls == [
-        call(10, 'mangle', '-D', 'OUTPUT', '-j', 'sshuttle-m-1024'),
-        call(10, 'mangle', '-F', 'sshuttle-m-1024'),
-        call(10, 'mangle', '-X', 'sshuttle-m-1024'),
-        call(10, 'mangle', '-D', 'PREROUTING', '-j', 'sshuttle-t-1024'),
-        call(10, 'mangle', '-F', 'sshuttle-t-1024'),
-        call(10, 'mangle', '-X', 'sshuttle-t-1024'),
-        call(10, 'mangle', '-F', 'sshuttle-d-1024'),
-        call(10, 'mangle', '-X', 'sshuttle-d-1024'),
-        call(10, 'mangle', '-N', 'sshuttle-m-1024'),
-        call(10, 'mangle', '-F', 'sshuttle-m-1024'),
-        call(10, 'mangle', '-N', 'sshuttle-d-1024'),
-        call(10, 'mangle', '-F', 'sshuttle-d-1024'),
-        call(10, 'mangle', '-N', 'sshuttle-t-1024'),
-        call(10, 'mangle', '-F', 'sshuttle-t-1024'),
-        call(10, 'mangle', '-I', 'OUTPUT', '1', '-j', 'sshuttle-m-1024'),
-        call(10, 'mangle', '-I', 'PREROUTING', '1', '-j', 'sshuttle-t-1024'),
-        call(10, 'mangle', '-A', 'sshuttle-d-1024', '-j', 'MARK',
+        call(AF_INET6, 'mangle', '-D', 'OUTPUT', '-j', 'sshuttle-m-1024'),
+        call(AF_INET6, 'mangle', '-F', 'sshuttle-m-1024'),
+        call(AF_INET6, 'mangle', '-X', 'sshuttle-m-1024'),
+        call(AF_INET6, 'mangle', '-D', 'PREROUTING', '-j', 'sshuttle-t-1024'),
+        call(AF_INET6, 'mangle', '-F', 'sshuttle-t-1024'),
+        call(AF_INET6, 'mangle', '-X', 'sshuttle-t-1024'),
+        call(AF_INET6, 'mangle', '-F', 'sshuttle-d-1024'),
+        call(AF_INET6, 'mangle', '-X', 'sshuttle-d-1024'),
+        call(AF_INET6, 'mangle', '-N', 'sshuttle-m-1024'),
+        call(AF_INET6, 'mangle', '-F', 'sshuttle-m-1024'),
+        call(AF_INET6, 'mangle', '-N', 'sshuttle-d-1024'),
+        call(AF_INET6, 'mangle', '-F', 'sshuttle-d-1024'),
+        call(AF_INET6, 'mangle', '-N', 'sshuttle-t-1024'),
+        call(AF_INET6, 'mangle', '-F', 'sshuttle-t-1024'),
+        call(AF_INET6, 'mangle', '-I', 'OUTPUT', '1', '-j', 'sshuttle-m-1024'),
+        call(AF_INET6, 'mangle', '-I', 'PREROUTING', '1', '-j',
+            'sshuttle-t-1024'),
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-d-1024', '-j', 'MARK',
              '--set-mark', '1'),
-        call(10, 'mangle', '-A', 'sshuttle-d-1024', '-j', 'ACCEPT'),
-        call(10, 'mangle', '-A', 'sshuttle-t-1024', '-m', 'socket',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-d-1024', '-j', 'ACCEPT'),
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-t-1024', '-m', 'socket',
              '-j', 'sshuttle-d-1024', '-m', 'tcp', '-p', 'tcp'),
-        call(10, 'mangle', '-A', 'sshuttle-t-1024', '-m', 'socket',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-t-1024', '-m', 'socket',
              '-j', 'sshuttle-d-1024', '-m', 'udp', '-p', 'udp'),
-        call(10, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'MARK',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'MARK',
              '--set-mark', '1', '--dest', u'2404:6800:4004:80c::33/32',
              '-m', 'udp', '-p', 'udp', '--dport', '53'),
-        call(10, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'TPROXY',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'TPROXY',
              '--tproxy-mark', '0x1/0x1',
              '--dest', u'2404:6800:4004:80c::33/32',
              '-m', 'udp', '-p', 'udp', '--dport', '53', '--on-port', '1026'),
-        call(10, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'RETURN',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'RETURN',
              '--dest', u'2404:6800:4004:80c::101f/128',
              '-m', 'tcp', '-p', 'tcp', '--dport', '8080:8080'),
-        call(10, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'RETURN',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'RETURN',
              '--dest', u'2404:6800:4004:80c::101f/128',
              '-m', 'tcp', '-p', 'tcp', '--dport', '8080:8080'),
-        call(10, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'RETURN',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'RETURN',
              '--dest', u'2404:6800:4004:80c::101f/128',
              '-m', 'udp', '-p', 'udp', '--dport', '8080:8080'),
-        call(10, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'RETURN',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'RETURN',
              '--dest', u'2404:6800:4004:80c::101f/128',
              '-m', 'udp', '-p', 'udp', '--dport', '8080:8080'),
-        call(10, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'MARK',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'MARK',
              '--set-mark', '1', '--dest', u'2404:6800:4004:80c::/64',
              '-m', 'tcp', '-p', 'tcp', '--dport', '8000:9000'),
-        call(10, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'TPROXY',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'TPROXY',
              '--tproxy-mark', '0x1/0x1', '--dest', u'2404:6800:4004:80c::/64',
              '-m', 'tcp', '-p', 'tcp', '--dport', '8000:9000',
              '--on-port', '1024'),
-        call(10, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'MARK',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-m-1024', '-j', 'MARK',
              '--set-mark', '1', '--dest', u'2404:6800:4004:80c::/64',
              '-m', 'udp', '-p', 'udp'),
-        call(10, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'TPROXY',
+        call(AF_INET6, 'mangle', '-A', 'sshuttle-t-1024', '-j', 'TPROXY',
              '--tproxy-mark', '0x1/0x1', '--dest', u'2404:6800:4004:80c::/64',
              '-m', 'udp', '-p', 'udp', '--dport', '8000:9000',
              '--on-port', '1024')
@@ -174,22 +178,22 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt_ttl, mock_ipt):
     mock_ipt_ttl.reset_mock()
     mock_ipt.reset_mock()
 
-    method.restore_firewall(1025, 10, True, None)
+    method.restore_firewall(1025, AF_INET6, True, None)
     assert mock_ipt_chain_exists.mock_calls == [
-        call(10, 'mangle', 'sshuttle-m-1025'),
-        call(10, 'mangle', 'sshuttle-t-1025'),
-        call(10, 'mangle', 'sshuttle-d-1025')
+        call(AF_INET6, 'mangle', 'sshuttle-m-1025'),
+        call(AF_INET6, 'mangle', 'sshuttle-t-1025'),
+        call(AF_INET6, 'mangle', 'sshuttle-d-1025')
     ]
     assert mock_ipt_ttl.mock_calls == []
     assert mock_ipt.mock_calls == [
-        call(10, 'mangle', '-D', 'OUTPUT', '-j', 'sshuttle-m-1025'),
-        call(10, 'mangle', '-F', 'sshuttle-m-1025'),
-        call(10, 'mangle', '-X', 'sshuttle-m-1025'),
-        call(10, 'mangle', '-D', 'PREROUTING', '-j', 'sshuttle-t-1025'),
-        call(10, 'mangle', '-F', 'sshuttle-t-1025'),
-        call(10, 'mangle', '-X', 'sshuttle-t-1025'),
-        call(10, 'mangle', '-F', 'sshuttle-d-1025'),
-        call(10, 'mangle', '-X', 'sshuttle-d-1025')
+        call(AF_INET6, 'mangle', '-D', 'OUTPUT', '-j', 'sshuttle-m-1025'),
+        call(AF_INET6, 'mangle', '-F', 'sshuttle-m-1025'),
+        call(AF_INET6, 'mangle', '-X', 'sshuttle-m-1025'),
+        call(AF_INET6, 'mangle', '-D', 'PREROUTING', '-j', 'sshuttle-t-1025'),
+        call(AF_INET6, 'mangle', '-F', 'sshuttle-t-1025'),
+        call(AF_INET6, 'mangle', '-X', 'sshuttle-t-1025'),
+        call(AF_INET6, 'mangle', '-F', 'sshuttle-d-1025'),
+        call(AF_INET6, 'mangle', '-X', 'sshuttle-d-1025')
     ]
     mock_ipt_chain_exists.reset_mock()
     mock_ipt_ttl.reset_mock()
@@ -199,69 +203,71 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt_ttl, mock_ipt):
 
     method.setup_firewall(
         1025, 1027,
-        [(2, u'1.2.3.33')],
-        2,
-        [(2, 24, False, u'1.2.3.0', 0, 0), (2, 32, True, u'1.2.3.66', 80, 80)],
+        [(AF_INET, u'1.2.3.33')],
+        AF_INET,
+        [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
+            (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
         True,
         None)
     assert mock_ipt_chain_exists.mock_calls == [
-        call(2, 'mangle', 'sshuttle-m-1025'),
-        call(2, 'mangle', 'sshuttle-t-1025'),
-        call(2, 'mangle', 'sshuttle-d-1025')
+        call(AF_INET, 'mangle', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', 'sshuttle-d-1025')
     ]
     assert mock_ipt_ttl.mock_calls == []
     assert mock_ipt.mock_calls == [
-        call(2, 'mangle', '-D', 'OUTPUT', '-j', 'sshuttle-m-1025'),
-        call(2, 'mangle', '-F', 'sshuttle-m-1025'),
-        call(2, 'mangle', '-X', 'sshuttle-m-1025'),
-        call(2, 'mangle', '-D', 'PREROUTING', '-j', 'sshuttle-t-1025'),
-        call(2, 'mangle', '-F', 'sshuttle-t-1025'),
-        call(2, 'mangle', '-X', 'sshuttle-t-1025'),
-        call(2, 'mangle', '-F', 'sshuttle-d-1025'),
-        call(2, 'mangle', '-X', 'sshuttle-d-1025'),
-        call(2, 'mangle', '-N', 'sshuttle-m-1025'),
-        call(2, 'mangle', '-F', 'sshuttle-m-1025'),
-        call(2, 'mangle', '-N', 'sshuttle-d-1025'),
-        call(2, 'mangle', '-F', 'sshuttle-d-1025'),
-        call(2, 'mangle', '-N', 'sshuttle-t-1025'),
-        call(2, 'mangle', '-F', 'sshuttle-t-1025'),
-        call(2, 'mangle', '-I', 'OUTPUT', '1', '-j', 'sshuttle-m-1025'),
-        call(2, 'mangle', '-I', 'PREROUTING', '1', '-j', 'sshuttle-t-1025'),
-        call(2, 'mangle', '-A', 'sshuttle-d-1025',
+        call(AF_INET, 'mangle', '-D', 'OUTPUT', '-j', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', '-F', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', '-X', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', '-D', 'PREROUTING', '-j', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', '-F', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', '-X', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', '-F', 'sshuttle-d-1025'),
+        call(AF_INET, 'mangle', '-X', 'sshuttle-d-1025'),
+        call(AF_INET, 'mangle', '-N', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', '-F', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', '-N', 'sshuttle-d-1025'),
+        call(AF_INET, 'mangle', '-F', 'sshuttle-d-1025'),
+        call(AF_INET, 'mangle', '-N', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', '-F', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', '-I', 'OUTPUT', '1', '-j', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', '-I', 'PREROUTING', '1', '-j',
+            'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', '-A', 'sshuttle-d-1025',
              '-j', 'MARK', '--set-mark', '1'),
-        call(2, 'mangle', '-A', 'sshuttle-d-1025', '-j', 'ACCEPT'),
-        call(2, 'mangle', '-A', 'sshuttle-t-1025', '-m', 'socket',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-d-1025', '-j', 'ACCEPT'),
+        call(AF_INET, 'mangle', '-A', 'sshuttle-t-1025', '-m', 'socket',
              '-j', 'sshuttle-d-1025', '-m', 'tcp', '-p', 'tcp'),
-        call(2, 'mangle', '-A', 'sshuttle-t-1025', '-m', 'socket',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-t-1025', '-m', 'socket',
              '-j', 'sshuttle-d-1025', '-m', 'udp', '-p', 'udp'),
-        call(2, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'MARK',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'MARK',
              '--set-mark', '1', '--dest', u'1.2.3.33/32',
              '-m', 'udp', '-p', 'udp', '--dport', '53'),
-        call(2, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'TPROXY',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'TPROXY',
              '--tproxy-mark', '0x1/0x1', '--dest', u'1.2.3.33/32',
              '-m', 'udp', '-p', 'udp', '--dport', '53', '--on-port', '1027'),
-        call(2, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'RETURN',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'RETURN',
              '--dest', u'1.2.3.66/32', '-m', 'tcp', '-p', 'tcp',
              '--dport', '80:80'),
-        call(2, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'RETURN',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'RETURN',
              '--dest', u'1.2.3.66/32', '-m', 'tcp', '-p', 'tcp',
              '--dport', '80:80'),
-        call(2, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'RETURN',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'RETURN',
              '--dest', u'1.2.3.66/32', '-m', 'udp', '-p', 'udp',
              '--dport', '80:80'),
-        call(2, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'RETURN',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'RETURN',
              '--dest', u'1.2.3.66/32', '-m', 'udp', '-p', 'udp',
              '--dport', '80:80'),
-        call(2, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'MARK',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'MARK',
              '--set-mark', '1', '--dest', u'1.2.3.0/24',
              '-m', 'tcp', '-p', 'tcp'),
-        call(2, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'TPROXY',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'TPROXY',
              '--tproxy-mark', '0x1/0x1', '--dest', u'1.2.3.0/24',
              '-m', 'tcp', '-p', 'tcp', '--on-port', '1025'),
-        call(2, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'MARK',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-m-1025', '-j', 'MARK',
              '--set-mark', '1', '--dest', u'1.2.3.0/24',
              '-m', 'udp', '-p', 'udp'),
-        call(2, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'TPROXY',
+        call(AF_INET, 'mangle', '-A', 'sshuttle-t-1025', '-j', 'TPROXY',
              '--tproxy-mark', '0x1/0x1', '--dest', u'1.2.3.0/24',
              '-m', 'udp', '-p', 'udp', '--on-port', '1025')
     ]
@@ -269,22 +275,22 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt_ttl, mock_ipt):
     mock_ipt_ttl.reset_mock()
     mock_ipt.reset_mock()
 
-    method.restore_firewall(1025, 2, True, None)
+    method.restore_firewall(1025, AF_INET, True, None)
     assert mock_ipt_chain_exists.mock_calls == [
-        call(2, 'mangle', 'sshuttle-m-1025'),
-        call(2, 'mangle', 'sshuttle-t-1025'),
-        call(2, 'mangle', 'sshuttle-d-1025')
+        call(AF_INET, 'mangle', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', 'sshuttle-d-1025')
     ]
     assert mock_ipt_ttl.mock_calls == []
     assert mock_ipt.mock_calls == [
-        call(2, 'mangle', '-D', 'OUTPUT', '-j', 'sshuttle-m-1025'),
-        call(2, 'mangle', '-F', 'sshuttle-m-1025'),
-        call(2, 'mangle', '-X', 'sshuttle-m-1025'),
-        call(2, 'mangle', '-D', 'PREROUTING', '-j', 'sshuttle-t-1025'),
-        call(2, 'mangle', '-F', 'sshuttle-t-1025'),
-        call(2, 'mangle', '-X', 'sshuttle-t-1025'),
-        call(2, 'mangle', '-F', 'sshuttle-d-1025'),
-        call(2, 'mangle', '-X', 'sshuttle-d-1025')
+        call(AF_INET, 'mangle', '-D', 'OUTPUT', '-j', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', '-F', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', '-X', 'sshuttle-m-1025'),
+        call(AF_INET, 'mangle', '-D', 'PREROUTING', '-j', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', '-F', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', '-X', 'sshuttle-t-1025'),
+        call(AF_INET, 'mangle', '-F', 'sshuttle-d-1025'),
+        call(AF_INET, 'mangle', '-X', 'sshuttle-d-1025')
     ]
     mock_ipt_chain_exists.reset_mock()
     mock_ipt_ttl.reset_mock()


### PR DESCRIPTION
Swap hardcoded AF_INET(6) values for Python-provided values as they
differ between Darwin and Linux (30 vs 10 for AF_INET6 for instance).

Rebase berdario's PR, fixed conflicts, fleshed out message.