### PR TITLE
Use flake8 to find Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,13 @@ python:
 - pypy
 
 install:
-    - travis_retry pip install -q pytest mock
+    - travis_retry pip install -q flake8 pytest mock
+
+before_script:
+    # stop the build if there are Python syntax errors or undefined names.
+    - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics; fi
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide.
+    - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics; fi
 
 script:
   - PYTHONPATH=. py.test

--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -2,9 +2,9 @@ import sys
 import zlib
 import imp
 
+verbosity = verbosity  # noqa: F821 must be a previously defined global
 z = zlib.decompressobj()
 while 1:
-    global verbosity
     name = sys.stdin.readline().strip()
     if name:
         name = name.decode("ASCII")
@@ -22,7 +22,7 @@ while 1:
             setattr(sys.modules[parent], parent_name, module)
 
         code = compile(content, name, "exec")
-        exec(code, module.__dict__) # nosec
+        exec(code, module.__dict__)  # nosec
         sys.modules[name] = module
     else:
         break


### PR DESCRIPTION
Undefined name '__verbosity__' in assembler.py...
* https://travis-ci.org/sshuttle/sshuttle/jobs/341649202#L440-L447

