### PR TITLE
Declare 'verbosity' as global variable to placate linters

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -4,6 +4,7 @@ import imp
 
 z = zlib.decompressobj()
 while 1:
+    global verbosity
     name = sys.stdin.readline().strip()
     if name:
         name = name.decode("ASCII")


### PR DESCRIPTION
Fixes an issue raised in #201