### PR TITLE
Stop using SO_REUSEADDR on sockets

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -160,13 +160,11 @@ class MultiListener:
         self.bind_called = True
         if address_v6 is not None:
             self.v6 = socket.socket(socket.AF_INET6, self.type, self.proto)
-            self.v6.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             self.v6.bind(address_v6)
         else:
             self.v6 = None
         if address_v4 is not None:
             self.v4 = socket.socket(socket.AF_INET, self.type, self.proto)
-            self.v4.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             self.v4.bind(address_v4)
         else:
             self.v4 = None


### PR DESCRIPTION
In order to address a bug where DNS queries are always sent to only one of the tunnels despite having established N tunnels with different DNS servers, UDP needs to bind to different ports and not use SO_REUSEADDR in socket (TCP already binds to different ports).
Originally mentioned on #153 .