### PR TITLE
Fix compatibility with the sudoers file

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -195,8 +195,8 @@ class FirewallClient:
         if ssyslog._p:
             argvbase += ['--syslog']
         argv_tries = [
-            ['sudo', '-p', '[local sudo] Password: ',
-                ('PYTHONPATH=%s' % python_path), '--'] + argvbase,
+            ['sudo', '-p', '[local sudo] Password: ', '/usr/bin/env',
+                ('PYTHONPATH=%s' % python_path)] + argvbase,
             argvbase
         ]
 


### PR DESCRIPTION
Starting sshuttle without having to type in one's password requires to
put the sudo-ed command in the `/etc/sudoers` file. However, sshuttle
sets an environment variable, which cannot be done as-is in the sudoers
file. This fix prepend the /usr/bin/env command, which allows one to
pass fixed environment variables to a sudo-ed command.

In practice, the sub-command:

```
sudo PYTHONPATH=/usr/lib/python3/dist-packages -- \
        /usr/bin/python3 /usr/bin/sshuttle --method auto --firewall
```

becomes

```
sudo /usr/bin/env PYTHONPATH=/usr/lib/python3/dist-packages \
        /usr/bin/python3 /usr/bin/sshuttle --method auto --firewall
```