### PR TITLE
Make --to-ns and --ns-hosts work well together

### DIFF
--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -174,7 +174,8 @@ class DnsProxy(Handler):
             self.to_nameserver = None
         else:
             self.to_ns_peer, self.to_ns_port = to_nameserver.split("@")
-            self.to_nameserver = self._addrinfo(self.to_ns_peer, self.to_ns_port)
+            self.to_nameserver = self._addrinfo(self.to_ns_peer,
+                                                self.to_ns_port)
         self.try_send()
 
     @staticmethod

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -192,6 +192,8 @@ class DnsProxy(Handler):
             port = 53
             family, sockaddr = self._addrinfo(peer, port)
         else:
+            _, peer = self.to_nameserver
+            port = 53
             family, sockaddr = self.to_nameserver
 
         sock = socket.socket(family, socket.SOCK_DGRAM)

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -168,11 +168,13 @@ class DnsProxy(Handler):
         self.tries = 0
         self.request = request
         self.peers = {}
+        self.to_ns_peer = None
+        self.to_ns_port = None
         if to_nameserver is None:
             self.to_nameserver = None
         else:
-            peer, port = to_nameserver.split("@")
-            self.to_nameserver = self._addrinfo(peer, port)
+            self.to_ns_peer, self.to_ns_port = to_nameserver.split("@")
+            self.to_nameserver = self._addrinfo(self.to_ns_peer, self.to_ns_port)
         self.try_send()
 
     @staticmethod
@@ -190,12 +192,11 @@ class DnsProxy(Handler):
         if self.to_nameserver is None:
             _, peer = resolvconf_random_nameserver()
             port = 53
-            family, sockaddr = self._addrinfo(peer, port)
         else:
-            _, peer = self.to_nameserver
-            port = 53
-            family, sockaddr = self.to_nameserver
+            peer = self.to_ns_peer
+            port = int(self.to_ns_port)
 
+        family, sockaddr = self._addrinfo(peer, port)
         sock = socket.socket(family, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_IP, socket.IP_TTL, 42)
         sock.connect(sockaddr)


### PR DESCRIPTION
I am loving using sshuttle as my poor person's VPN.  I use the --to-ns and the --ns-hosts options along with --dns and domain-specific resolver files in /etc/resolver to route only private DNS zones over the connection, and discovered that it didn't seem to work.

This fixed the problem for me.