### PR TITLE
Fix nftables support when forward ports are specified

### DIFF
--- a/sshuttle/methods/nft.py
+++ b/sshuttle/methods/nft.py
@@ -41,7 +41,9 @@ class Method(BaseMethod):
                 in sorted(subnets, key=subnet_weight, reverse=True):
             tcp_ports = ('ip', 'protocol', 'tcp')
             if fport and fport != lport:
-                tcp_ports = tcp_ports + ('tcp', 'dport', '{ %d-%d }' % (fport, lport))
+                tcp_ports = \
+                    tcp_ports + \
+                    ('tcp', 'dport', '{ %d-%d }' % (fport, lport))
             elif fport and fport == lport:
                 tcp_ports = tcp_ports + ('tcp', 'dport', '%d' % (fport))
 

--- a/sshuttle/methods/nft.py
+++ b/sshuttle/methods/nft.py
@@ -40,8 +40,10 @@ class Method(BaseMethod):
         for _, swidth, sexclude, snet, fport, lport \
                 in sorted(subnets, key=subnet_weight, reverse=True):
             tcp_ports = ('ip', 'protocol', 'tcp')
-            if fport:
-                tcp_ports = tcp_ports + ('dport { %d-%d }' % (fport, lport))
+            if fport and fport != lport:
+                tcp_ports = tcp_ports + ('tcp', 'dport', '{ %d-%d }' % (fport, lport))
+            elif fport and fport == lport:
+                tcp_ports = tcp_ports + ('tcp', 'dport', '%d' % (fport))
 
             if sexclude:
                 _nft('add rule', chain, *(tcp_ports + (


### PR DESCRIPTION
This complements #211 related to support for `nftables`.

The current implementation in `0.78.4` throws an exception when the user specifies a specific port or a range of ports to be forwarded. The current code had three issues:

 * trying to concatenate a string `(dport { %d-%d })` to the option tuples _(python error)_
 * appending `dport { %d-%d }` instead of `tcp dport { %d-%d }` _(nft error)_
 * using range notation even when forwarding a single port, which nft forbids _(nft error)_

This PR fixes those issues.