### PR TITLE
[WiP] Add efficient Internet censorship circumvention using --table

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Contents:
    support
    trivia
    changes
+   table
 
 
 Indices and tables

--- a/docs/table.rst
+++ b/docs/table.rst
@@ -1,0 +1,29 @@
+Tables
+======
+
+"Table" feature enables efficient circumvention of some
+implementations of Internet censorship. The idea is that you create a
+text file that lists IP addresses, subnetworks and domains that should
+be unblocked, for example:
+
+    *.rutracker.org
+    *.linkedin.com
+    95.211.178.194
+    51.136.0.0/15
+
+and pass this file to sshuttle using ``--table path_to_the_file``
+option.  sshuttle will redirect all the traffic to the specified IPs
+and subnets via the ssh connection. Moreover, if you use ``--dns``
+option, it will monitor DNS requests and add any IP addresses for
+blocked domains to the list of IPs to unblock, at the same time
+updating the table file, so restarting sshuttle will not cause any
+problems due to local DNS response caching.
+
+This "wholesale" circumvention method is implemented using `ipset`
+command on Linux and pf 'table' feature of Mac OS X (it may also
+work with FreeBSD but this is currently untested). This way,
+you can easily add hundreds of thousands of IPs and domain names
+to the table without overwhelming your system resources.
+
+The feature is currently supported by 'pf' (tested on Mac OS X) and
+'nat' methods.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 setuptools-scm==1.15.6
+dnslib==0.9.7

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -246,7 +246,7 @@ class FirewallClient:
 
     def setup(self, subnets_include, subnets_exclude, nslist,
               redirectport_v6, redirectport_v4, dnsport_v6, dnsport_v4, udp,
-              user):
+              user, table):
         self.subnets_include = subnets_include
         self.subnets_exclude = subnets_exclude
         self.nslist = nslist
@@ -256,6 +256,7 @@ class FirewallClient:
         self.dnsport_v4 = dnsport_v4
         self.udp = udp
         self.user = user
+        self.table = table
 
     def check(self):
         rv = self.p.poll()
@@ -281,6 +282,9 @@ class FirewallClient:
             b'PORTS %d,%d,%d,%d\n'
             % (self.redirectport_v6, self.redirectport_v4,
                self.dnsport_v6, self.dnsport_v4))
+
+        if self.table:
+            self.pfile.write(b'TABLE %s\n' % self.table)
 
         udp = 0
         if self.udp:
@@ -550,7 +554,7 @@ def main(listenip_v6, listenip_v4,
          ssh_cmd, remotename, python, latency_control, dns, nslist,
          method_name, seed_hosts, auto_hosts, auto_nets,
          subnets_include, subnets_exclude, daemon, to_nameserver, pidfile,
-         user):
+         user, table):
 
     if daemon:
         try:
@@ -775,7 +779,7 @@ def main(listenip_v6, listenip_v4,
     # start the firewall
     fw.setup(subnets_include, subnets_exclude, nslist,
              redirectport_v6, redirectport_v4, dnsport_v6, dnsport_v4,
-             required.udp, user)
+             required.udp, user, table)
 
     # start the client process
     try:

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -77,7 +77,8 @@ def main():
                                       opt.to_ns,
                                       opt.pidfile,
                                       opt.user,
-                                      opt.table)
+                                      opt.table,
+                                      opt.dns_table)
 
             if return_code == 0:
                 log('Normal exit code, exiting...')

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -77,8 +77,7 @@ def main():
                                       opt.to_ns,
                                       opt.pidfile,
                                       opt.user,
-                                      opt.table,
-                                      opt.dns_table)
+                                      opt.table)
 
             if return_code == 0:
                 log('Normal exit code, exiting...')

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -76,7 +76,8 @@ def main():
                                       opt.daemon,
                                       opt.to_ns,
                                       opt.pidfile,
-                                      opt.user)
+                                      opt.user,
+                                      opt.table)
 
             if return_code == 0:
                 log('Normal exit code, exiting...')

--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -247,7 +247,7 @@ def main(method_name, syslog):
                 debug2('firewall manager: setting up /etc/hosts.\n')
                 rewrite_etc_hosts(hostmap, port_v6 or port_v4)
             elif line.startswith('ADD_TO_TABLE '):
-                _, _, addrs = line.partition(' ')
+                _, _, addrs = line.strip().partition(' ')
                 method.add_to_table(port_v4, socket.AF_INET, addrs.split(' '))
             elif line:
                 if not method.firewall_command(line):
@@ -277,7 +277,7 @@ def main(method_name, syslog):
         try:
             if subnets_v4 or nslist_v4:
                 debug2('firewall manager: undoing IPv4 changes.\n')
-                method.restore_firewall(port_v4, socket.AF_INET, udp, user)
+                method.restore_firewall(port_v4, socket.AF_INET, udp, user, table_path)
         except:
             try:
                 debug1("firewall manager: "

--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -183,7 +183,14 @@ def main(method_name, syslog):
     debug2('firewall manager: Got ports: %d,%d,%d,%d\n'
            % (port_v6, port_v4, dnsport_v6, dnsport_v4))
 
+    table_path = ''
     line = stdin.readline(128)
+    if line.startswith('TABLE '):
+        _, _, table_path = line.partition(" ")
+        table_path = table_path.strip()
+        if not table_path:
+            raise Fatal('firewall: TABLE path not specified')
+        line = stdin.readline(128)
     if not line:
         raise Fatal('firewall: expected GO but got %r' % line)
     elif not line.startswith("GO "):
@@ -209,14 +216,14 @@ def main(method_name, syslog):
             method.setup_firewall(
                 port_v6, dnsport_v6, nslist_v6,
                 socket.AF_INET6, subnets_v6, udp,
-                user)
+                user, table_path)
 
         if subnets_v4 or nslist_v4:
             debug2('firewall manager: setting up IPv4.\n')
             method.setup_firewall(
                 port_v4, dnsport_v4, nslist_v4,
                 socket.AF_INET, subnets_v4, udp,
-                user)
+                user, table_path)
 
         stdout.write('STARTED\n')
         sdnotify.send(sdnotify.ready(),

--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -246,6 +246,9 @@ def main(method_name, syslog):
                 hostmap[name] = ip
                 debug2('firewall manager: setting up /etc/hosts.\n')
                 rewrite_etc_hosts(hostmap, port_v6 or port_v4)
+            elif line.startswith('ADD_TO_TABLE '):
+                _, _, addrs = line.partition(' ')
+                method.add_to_table(port_v4, socket.AF_INET, addrs.split(' '))
             elif line:
                 if not method.firewall_command(line):
                     raise Fatal('firewall: expected command, got %r' % line)

--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -103,3 +103,18 @@ def ipt_ttl(family, *args):
             _no_ttl_module = True
     else:
         ipt(family, *args)
+
+def ipset(args, stdin=None):
+    argv = ['ipset'] + list(args)
+    debug1('>> %s\n' % ' '.join(argv))
+    env = {
+        'PATH': os.environ['PATH'],
+        'LC_ALL': "C",
+    }
+    p = ssubprocess.Popen(argv, stdin=ssubprocess.PIPE,
+                          stdout=ssubprocess.PIPE,
+                          # stderr=ssubprocess.PIPE,
+                          env=env)
+    p.communicate(stdin)
+    if p.returncode:
+        raise Fatal('%r returned %d' % (argv, p.returncode))

--- a/sshuttle/methods/__init__.py
+++ b/sshuttle/methods/__init__.py
@@ -82,7 +82,7 @@ class BaseMethod(object):
         raise NotImplementedError()
 
     def add_to_table(self, port, family, addrs):
-        log('warning: add_to_table not implemented')
+        debug3('warning: add_to_table not implemented\n')
 
     @staticmethod
     def firewall_command(line):

--- a/sshuttle/methods/__init__.py
+++ b/sshuttle/methods/__init__.py
@@ -81,6 +81,9 @@ class BaseMethod(object):
     def restore_firewall(self, port, family, udp, user):
         raise NotImplementedError()
 
+    def add_to_table(self, port, family, addrs):
+        log('warning: add_to_table not implemented')
+
     @staticmethod
     def firewall_command(line):
         return False

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -192,12 +192,14 @@ class Method(BaseMethod):
         #    udp_listener.v6.setsockopt(SOL_IPV6, IPV6_RECVDSTADDR, 1)
 
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
-                       user):
+                       user, subnet_table=None):
         # IPv6 not supported
         if family not in [socket.AF_INET]:
             raise Exception(
                 'Address family "%s" unsupported by ipfw method_name'
                 % family_to_string(family))
+        if subnet_table:
+            raise Exception('subnet_table not supported by ipfw')
 
         #XXX: Any risk from this?
         ipfw_noexit('delete', '1')
@@ -245,7 +247,7 @@ class Method(BaseMethod):
             else:
                 ipfw('table', '126', 'add', '%s/%s' % (snet, swidth))
 
-    def restore_firewall(self, port, family, udp, user):
+    def restore_firewall(self, port, family, udp, user, use_table=False):
         if family not in [socket.AF_INET]:
             raise Exception(
                 'Address family "%s" unsupported by tproxy method'

--- a/sshuttle/methods/nft.py
+++ b/sshuttle/methods/nft.py
@@ -12,9 +12,11 @@ class Method(BaseMethod):
     # recently-started one will win (because we use "-I OUTPUT 1" instead of
     # "-A OUTPUT").
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
-                       user):
+                       user, subnet_table=None):
         if udp:
             raise Exception("UDP not supported by nft")
+        if subnet_table:
+            raise Exception('subnet_table not supported by nft')
 
         table = "nat"
 
@@ -65,7 +67,7 @@ class Method(BaseMethod):
                      'udp dport { 53 }', 'ip ttl != 42',
                      ('redirect to :' + str(dnsport)))
 
-    def restore_firewall(self, port, family, udp, user):
+    def restore_firewall(self, port, family, udp, user, use_table=False):
         if udp:
             raise Exception("UDP not supported by nft method_name")
 

--- a/sshuttle/methods/tproxy.py
+++ b/sshuttle/methods/tproxy.py
@@ -151,11 +151,13 @@ class Method(BaseMethod):
             udp_listener.v6.setsockopt(SOL_IPV6, IPV6_RECVORIGDSTADDR, 1)
 
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
-                       user):
+                       user, subnet_table=False):
         if family not in [socket.AF_INET, socket.AF_INET6]:
             raise Exception(
                 'Address family "%s" unsupported by tproxy method'
                 % family_to_string(family))
+        if subnet_table:
+            raise Exception('subnet_table not supported by tproxy')
 
         table = "mangle"
 
@@ -252,7 +254,7 @@ class Method(BaseMethod):
                          '-m', 'udp',
                          *(udp_ports + ('--on-port', str(port))))
 
-    def restore_firewall(self, port, family, udp, user):
+    def restore_firewall(self, port, family, udp, user, use_table=False):
         if family not in [socket.AF_INET, socket.AF_INET6]:
             raise Exception(
                 'Address family "%s" unsupported by tproxy method'

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -310,3 +310,10 @@ parser.add_argument(
     (internal use only)
     """
 )
+parser.add_argument(
+    "--table",
+    metavar="PATH",
+    help="""
+use subnet table
+"""
+    )

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -317,10 +317,3 @@ parser.add_argument(
 use subnet table
 """
     )
-parser.add_argument(
-    "--dns-table",
-    metavar="PATH",
-    help="""
-use dns table
-"""
-    )

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -317,3 +317,10 @@ parser.add_argument(
 use subnet table
 """
     )
+parser.add_argument(
+    "--dns-table",
+    metavar="PATH",
+    help="""
+use dns table
+"""
+    )

--- a/sshuttle/tests/client/test_firewall.py
+++ b/sshuttle/tests/client/test_firewall.py
@@ -122,7 +122,8 @@ def test_main(mock_get_method, mock_setup_daemon, mock_rewrite_etc_hosts):
             [(AF_INET6, 64, False, u'2404:6800:4004:80c::', 0, 0),
                 (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 80, 80)],
             True,
-            None),
+            None,
+            ''),
         call().setup_firewall(
             1025, 1027,
             [(AF_INET, u'1.2.3.33')],
@@ -130,7 +131,8 @@ def test_main(mock_get_method, mock_setup_daemon, mock_rewrite_etc_hosts):
             [(AF_INET, 24, False, u'1.2.3.0', 8000, 9000),
                 (AF_INET, 32, True, u'1.2.3.66', 8080, 8080)],
             True,
-            None),
+            None,
+            ''),
         call().restore_firewall(1024, AF_INET6, True, None),
-        call().restore_firewall(1025, AF_INET, True, None),
+        call().restore_firewall(1025, AF_INET, True, None, ''),
     ]


### PR DESCRIPTION
This PR adds a way to use sshuttle as an efficient Internet censorship circumvention tool. It makes use of `ipset` on Linux and pf tables on Mac OS X (it may also work on FreeBSD but that's untested). The idea is that you create a text file that lists IP addresses, subnetworks and domains that should
be unblocked, for example:

```
*.rutracker.org
*.linkedin.com
95.211.178.194
51.136.0.0/15
```

and pass this file to sshuttle using ``--table path_to_the_file`` option.  sshuttle will redirect all the traffic to the specified IPs and subnets via the ssh connection. Moreover, if you use ``--dns`` option, it will monitor DNS requests and add any IP addresses for blocked domains to the list of IPs to unblock, at the same time updating the table file, so restarting sshuttle will not cause any problems due to local DNS response caching.

There are some rough edges still, for example:

- more test coverage is probably needed
- the user should not need to specify any subnets or IPs in the command line if `--table` is used
- `tproxy` method should be probably supported
- try to support \*BSD
- clean up the code (pardon my Python, I've mostly switched to Go several years ago)

Please let me know if you're interested in this use case for sshuttle.
