### PR TITLE
Added coverage report to tests

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 pytest==3.4.2
+pytest-cov==2.6.0
 mock==2.0.0
 flake8==3.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ universal = 1
 [upload]
 sign=true
 identity=0x1784577F811F6EAC
+
+[tool:pytest]
+addopts = --cov=sshuttle --cov-branch --cov-report=term-missing

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,12 @@ setup(
             'sshuttle = sshuttle.cmdline:main',
         ],
     },
-    tests_require=['pytest', 'pytest-runner', 'mock'],
+    tests_require=[
+        'pytest',
+        'pytest-cov',
+        'pytest-runner',
+        'mock',
+        'flake8',
+    ],
     keywords="ssh vpn",
 )


### PR DESCRIPTION
This PR adds coverage report to the test output. It is purely informative and will not cause the tests to fail. Using the output you can easily spot which parts of the code could use more testing.