### PR TITLE
Fixes support for OpenBSD (6.1+)

### DIFF
--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -261,7 +261,7 @@ class OpenBsd(Generic):
                         ("proto_variant", c_uint8),
                         ("direction", c_uint8)]
 
-        self.pfioc_rule = c_char * 3400
+        self.pfioc_rule = c_char * 3416
         self.pfioc_natlook = pfioc_natlook
         super(OpenBsd, self).__init__()
 

--- a/tests/client/test_methods_pf.py
+++ b/tests/client/test_methods_pf.py
@@ -403,8 +403,8 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         None)
 
     assert mock_ioctl.mock_calls == [
-        call(mock_pf_get_dev(), 0xcd48441a, ANY),
-        call(mock_pf_get_dev(), 0xcd48441a, ANY),
+        call(mock_pf_get_dev(), 0xcd58441a, ANY),
+        call(mock_pf_get_dev(), 0xcd58441a, ANY),
     ]
     assert mock_pfctl.mock_calls == [
         call('-s Interfaces -i lo -v'),
@@ -451,8 +451,8 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         False,
         None)
     assert mock_ioctl.mock_calls == [
-        call(mock_pf_get_dev(), 0xcd48441a, ANY),
-        call(mock_pf_get_dev(), 0xcd48441a, ANY),
+        call(mock_pf_get_dev(), 0xcd58441a, ANY),
+        call(mock_pf_get_dev(), 0xcd58441a, ANY),
     ]
     assert mock_pfctl.mock_calls == [
         call('-s Interfaces -i lo -v'),


### PR DESCRIPTION
New versions of OpenBSD ship with a different `pfioc_rule` struct. This commit adjusts the offset to match the new struct.

Should fix #219.

For reference, used the following C program to compute the new size.

```c
#include <stdio.h>
#include <sys/types.h>
#include <sys/socket.h>
#include <net/if.h>
#include <net/pfvar.h>

int main() {
        int size = sizeof(struct pfioc_rule);
        printf("Size: %d\n", size);
        return 0;
}
```