### PR TITLE
Close stdin, stdout, and stderr when using syslog or forking to daemon

### DIFF
--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -59,6 +59,8 @@ def main():
                 ipport_v6 = "auto" if not opt.disable_ipv6 else None
             if opt.syslog:
                 ssyslog.start_syslog()
+                ssyslog.close_stdin()
+                ssyslog.stdout_to_syslog()
                 ssyslog.stderr_to_syslog()
             return_code = client.main(ipport_v6, ipport_v4,
                                       opt.ssh_cmd,

--- a/sshuttle/ssyslog.py
+++ b/sshuttle/ssyslog.py
@@ -8,12 +8,24 @@ _p = None
 
 def start_syslog():
     global _p
-    _p = ssubprocess.Popen(['logger',
-                            '-p', 'daemon.notice',
-                            '-t', 'sshuttle'], stdin=ssubprocess.PIPE)
+    devnull = open(os.devnull, 'w')
+    _p = ssubprocess.Popen(
+        ['logger', '-p', 'daemon.notice', '-t', 'sshuttle'],
+        stdin=ssubprocess.PIPE,
+        stdout=devnull,
+        stderr=devnull
+    )
+
+
+def close_stdin():
+    sys.stdin.close()
+
+
+def stdout_to_syslog():
+    sys.stdout.flush()
+    os.dup2(_p.stdin.fileno(), sys.stdout.fileno())
 
 
 def stderr_to_syslog():
-    sys.stdout.flush()
     sys.stderr.flush()
-    os.dup2(_p.stdin.fileno(), 2)
+    os.dup2(_p.stdin.fileno(), sys.stderr.fileno())


### PR DESCRIPTION
Fixes #139