### PR TITLE
Link Directly to TCP Over TCP Explanation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,9 @@ common case:
 
 - You can't use openssh's PermitTunnel feature because
   it's disabled by default on openssh servers; plus it does
-  TCP-over-TCP, which has terrible performance (see below).
-
+  TCP-over-TCP, which has `terrible performance`_.
+  
+.. _terrible performance: https://sshuttle.readthedocs.io/en/stable/how-it-works.html
 
 Obtaining sshuttle
 ------------------


### PR DESCRIPTION
See Below was confusing because it linked to the entire documentation section.
This provides a direct link to the section explaining why TCP over TCP is a bad idea.