### PR TITLE
Fix deadlock with iptables with large ruleset

### DIFF
--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -24,13 +24,12 @@ def ipt_chain_exists(family, table, name):
         'PATH': os.environ['PATH'],
         'LC_ALL': "C",
     }
-    p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=env)
-    for line in p.stdout:
-        if line.startswith(b'Chain %s ' % name.encode("ASCII")):
+    completed = ssubprocess.run(argv, stdout=ssubprocess.PIPE, env=env, encoding='ASCII')
+    if completed.returncode:
+        raise Fatal('%r returned %d' % (argv, completed.returncode))
+    for line in completed.stdout.split('\n'):
+        if line.startswith('Chain %s ' % name):
             return True
-    rv = p.wait()
-    if rv:
-        raise Fatal('%r returned %d' % (argv, rv))
 
 
 def ipt(family, table, *args):


### PR DESCRIPTION
Fixes #292 

This fixes an iptables deadlock condition when running sshuttle with a large set of routes. See the commit message for the full details.

I'm raising this as a PR here as requested, but I should note that I am by no means a Python developer.  I've tested this diff against 0.78.3 (as shipped with Ubuntu Bionic), and it has fixed the issue for me. I've not been able to test against other Python versions though, and from the docs I'm not clear that the `subprocess.run` method is available in all versions. I'd appreciate pointers in how to achieve this in a more portable manner. (I don't think this function has test coverage, so I don't think Travis will necessarily catch this)

I'd also note that the `nft_get_handle` function in this file uses the same pattern, and therefore may also be susceptible to this issue. This function doesn't exsit in the version I'm using. Let me know if you'd like the same fix to be applied there as well.