### PR TITLE
Fix potential deadlock condition in nft_get_handle and use subprocess.check_output

### DIFF
--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -74,13 +74,13 @@ def nft_get_handle(expression, chain):
         'PATH': os.environ['PATH'],
         'LC_ALL': "C",
     }
-    p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=env)
-    for line in p.stdout:
-        if (b'jump %s' % chain.encode('utf-8')) in line:
-            return re.sub('.*# ', '', line.decode('utf-8'))
-    rv = p.wait()
-    if rv:
-        raise Fatal('%r returned %d' % (argv, rv))
+    try:
+        output = ssubprocess.check_output(argv, env=env)
+        for line in output.decode('utf-8').split('\n'):
+            if ('jump %s' % chain) in line:
+                return re.sub('.*# ', '', line)
+    except ssubprocess.CalledProcessError as e:
+        raise Fatal('%r returned %d' % (argv, e.returncode))
 
 
 _no_ttl_module = False

--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -24,12 +24,13 @@ def ipt_chain_exists(family, table, name):
         'PATH': os.environ['PATH'],
         'LC_ALL': "C",
     }
-    completed = ssubprocess.run(argv, stdout=ssubprocess.PIPE, env=env, encoding='ASCII')
-    if completed.returncode:
-        raise Fatal('%r returned %d' % (argv, completed.returncode))
-    for line in completed.stdout.split('\n'):
-        if line.startswith('Chain %s ' % name):
-            return True
+    try:
+        output = ssubprocess.check_output(argv, env=env)
+        for line in output.decode('ASCII').split('\n'):
+            if line.startswith('Chain %s ' % name):
+                return True
+    except ssubprocess.CalledProcessError as e:
+        raise Fatal('%r returned %d' % (argv, e.returncode))
 
 
 def ipt(family, table, *args):


### PR DESCRIPTION
As requested in #293 this updates `nft_get_handle` to avoid the same potential deadlock condition. sorry this took a while, I had to find time to spin up a VM with nftables to test this in.

I've also included a commit to switch from using `subprocess.run` to `subprocess.check_output` as the latter is available in python 2.7. (Fixes #301).