### PR TITLE
auto-nets: retrieve routes only if using auto-nets

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -35,4 +35,5 @@ sshuttle.helpers.verbose = verbosity
 
 import sshuttle.cmdline_options as options
 from sshuttle.server import main
-main(options.latency_control, options.auto_hosts, options.to_nameserver)
+main(options.latency_control, options.auto_hosts, options.to_nameserver,
+     options.auto_nets)

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -453,7 +453,8 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
             stderr=ssyslog._p and ssyslog._p.stdin,
             options=dict(latency_control=latency_control,
                          auto_hosts=auto_hosts,
-                         to_nameserver=to_nameserver))
+                         to_nameserver=to_nameserver,
+                         auto_nets=auto_nets))
     except socket.error as e:
         if e.args[0] == errno.EPIPE:
             raise Fatal("failed to establish ssh session (1)")

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -279,7 +279,7 @@ class UdpProxy(Handler):
         self.mux.send(self.chan, ssnet.CMD_UDP_DATA, hdr + data)
 
 
-def main(latency_control, auto_hosts, to_nameserver):
+def main(latency_control, auto_hosts, to_nameserver, auto_nets):
     debug1('Starting server with Python version %s\n'
            % platform.python_version())
 
@@ -289,10 +289,6 @@ def main(latency_control, auto_hosts, to_nameserver):
         helpers.logprefix = 'server: '
     debug1('latency control setting = %r\n' % latency_control)
 
-    routes = list(list_routes())
-    debug1('available routes:\n')
-    for r in routes:
-        debug1('  %d/%s/%d\n' % r)
 
     # synchronization header
     sys.stdout.write('\0\0SSHUTTLE0001')
@@ -304,6 +300,16 @@ def main(latency_control, auto_hosts, to_nameserver):
               socket.fromfd(sys.stdout.fileno(),
                             socket.AF_INET, socket.SOCK_STREAM))
     handlers.append(mux)
+
+    debug1('auto-nets:' + str(auto_nets) + '\n')
+    if auto_nets:
+        routes = list(list_routes())
+        debug1('available routes:\n')
+        for r in routes:
+            debug1('  %d/%s/%d\n' % r)
+    else:
+        routes = []
+
     routepkt = ''
     for r in routes:
         routepkt += '%d,%s,%d\n' % r


### PR DESCRIPTION
There's a known issue that makes sshuttle crash if there are too
many routes on the remote host (that don't fit in 64KB). This patch
requests the routes only if auto-nets is specified on the command
line.