### PR TITLE
Hyphen in hostname fix

### DIFF
--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -32,7 +32,7 @@ def parse_subnetport(s):
     if s.count(':') > 1:
         rx = r'(?:\[?([\w\:]+)(?:/(\d+))?]?)(?::(\d+)(?:-(\d+))?)?$'
     else:
-        rx = r'([\w\.]+)(?:/(\d+))?(?::(\d+)(?:-(\d+))?)?$'
+        rx = r'([\w\.\-]+)(?:/(\d+))?(?::(\d+)(?:-(\d+))?)?$'
 
     m = re.match(rx, s)
     if not m:
@@ -63,7 +63,7 @@ def parse_ipport(s):
     elif ']' in s:
         rx = r'(?:\[([^]]+)])(?::(\d+))?$'
     else:
-        rx = r'([\w\.]+)(?::(\d+))?$'
+        rx = r'([\w\.\-]+)(?::(\d+))?$'
 
     m = re.match(rx, s)
     if not m:


### PR DESCRIPTION
(Apologies for closing and opening a related pull request. I had not put this change in its own branch)

Thank you for creating sshuttle, it's an awesome tool that's been invaluable on numerous occasions!

Earlier today I ran into an issue when I tried to use a hostname with a hyphen in one of its labels (e.g. `my-server.foobar.com`) due to the current regex `rx = r'([\w\.]+)(?:/(\d+))?(?::(\d+)(?:-(\d+))?)?$'` in `options.py` not accounting for hyphens.

The quickest (and simplest) fix which passes the Travis unit tests was to add a hyphen in the list of allowed characters and to update `([\w\.]+)` to `([\w\.\-]+)`.

