### PR TITLE
assembler import fix

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -2,10 +2,6 @@ import sys
 import zlib
 import imp
 
-import sshuttle.helpers
-import sshuttle.cmdline_options as options
-from sshuttle.server import main
-
 verbosity = verbosity  # noqa: F821 must be a previously defined global
 z = zlib.decompressobj()
 while 1:
@@ -34,7 +30,10 @@ while 1:
 sys.stderr.flush()
 sys.stdout.flush()
 
+import sshuttle.helpers
 sshuttle.helpers.verbose = verbosity
 
+import sshuttle.cmdline_options as options
+from sshuttle.server import main
 main(options.latency_control, options.auto_hosts, options.to_nameserver,
      options.auto_nets)

--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -30,7 +30,7 @@ while 1:
 sys.stderr.flush()
 sys.stdout.flush()
 
-# import can only happen once the code has been transferred to 
+# import can only happen once the code has been transferred to
 # the server. 'noqa: E402' excludes these lines from QA checks.
 import sshuttle.helpers  # noqa: E402
 sshuttle.helpers.verbose = verbosity

--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -30,10 +30,12 @@ while 1:
 sys.stderr.flush()
 sys.stdout.flush()
 
-import sshuttle.helpers
+# import can only happen once the code has been transferred to 
+# the server. 'noqa: E402' excludes these lines from QA checks.
+import sshuttle.helpers  # noqa: E402
 sshuttle.helpers.verbose = verbosity
 
-import sshuttle.cmdline_options as options
-from sshuttle.server import main
+import sshuttle.cmdline_options as options  # noqa: E402
+from sshuttle.server import main  # noqa: E402
 main(options.latency_control, options.auto_hosts, options.to_nameserver,
      options.auto_nets)


### PR DESCRIPTION
This is a pull request to fix https://github.com/sshuttle/sshuttle/issues/314

The most recent commit moved 3 import statements in `assembler.py` to the top of the code which causes them to be executed prior to the packages being available server-side. This fix moves them back to their original location from release 0.78.5.