### PR TITLE
Allow swtiching hostwatch cache file via $TMPDIR

### DIFF
--- a/sshuttle/hostwatch.py
+++ b/sshuttle/hostwatch.py
@@ -5,6 +5,7 @@ import select
 import errno
 import os
 import sys
+import tempfile
 import platform
 
 import subprocess as ssubprocess
@@ -13,7 +14,7 @@ from sshuttle.helpers import log, debug1, debug2, debug3
 
 POLL_TIME = 60 * 15
 NETSTAT_POLL_TIME = 30
-CACHEFILE = os.path.expanduser('~/.sshuttle.hosts')
+CACHEFILE = os.path.join(tempfile.gettempdir(), '.sshuttle.hosts.' + str(os.getuid()))
 
 
 _nmb_ok = True


### PR DESCRIPTION
This patch allows user to change the cache file location by passing `$TMPDIR` variable or one of those supported by `tempfile.tempdir` over SSH.

This is desiged for container environment that has `$HOME` being read-only and the writeable location will be  `tmpfs` mounted somewhere, e.g. `/tmp`.