### PR TITLE
Fix Arch linux installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Obtaining sshuttle
       
 - Arch Linux::
 
-      pacman -Sy sshuttle
+      pacman -S sshuttle
 
 - Fedora::
 


### PR DESCRIPTION
`pacman -Sy` does a partial upgrade, which is [specifically documented as being unsupported](https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported).