### PR TITLE
The size of pfioc_rule grew in OpenBSD 6.4

### DIFF
--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -262,7 +262,7 @@ class OpenBsd(Generic):
                         ("proto_variant", c_uint8),
                         ("direction", c_uint8)]
 
-        self.pfioc_rule = c_char * 3416
+        self.pfioc_rule = c_char * 3424
         self.pfioc_natlook = pfioc_natlook
         super(OpenBsd, self).__init__()
 

--- a/tests/client/test_methods_pf.py
+++ b/tests/client/test_methods_pf.py
@@ -403,8 +403,8 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         None)
 
     assert mock_ioctl.mock_calls == [
-        call(mock_pf_get_dev(), 0xcd58441a, ANY),
-        call(mock_pf_get_dev(), 0xcd58441a, ANY),
+        call(mock_pf_get_dev(), 0xcd60441a, ANY),
+        call(mock_pf_get_dev(), 0xcd60441a, ANY),
     ]
     assert mock_pfctl.mock_calls == [
         call('-s Interfaces -i lo -v'),
@@ -451,8 +451,8 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         False,
         None)
     assert mock_ioctl.mock_calls == [
-        call(mock_pf_get_dev(), 0xcd58441a, ANY),
-        call(mock_pf_get_dev(), 0xcd58441a, ANY),
+        call(mock_pf_get_dev(), 0xcd60441a, ANY),
+        call(mock_pf_get_dev(), 0xcd60441a, ANY),
     ]
     assert mock_pfctl.mock_calls == [
         call('-s Interfaces -i lo -v'),


### PR DESCRIPTION
Specifically in this revision:
openbsd/src@64d55eb2a2f453fba861fc092ebf3df4993ab9a0

I confirmed this by using the test program provided from #282 and some bisecting.

test.c:
```
#include <stdio.h>
#include <sys/types.h>
#include <sys/socket.h>
#include <net/if.h>
#include "testdir/pfvar.h"

int main() {
        int size = sizeof(struct pfioc_rule);
        printf("Size: %d\n", size);
        return 0;
}
```

results:
```
$ cvs -d anoncvs@anoncvs.usa.openbsd.org:/cvs export -d testdir -nlr OPENBSD_6_3 src/sys/net/pfvar.h
U testdir/pfvar.h
$ cc -o test test.c
$ ./test
Size: 3416
$ rm -rf testdir
$ cvs -d anoncvs@anoncvs.usa.openbsd.org:/cvs export -d testdir -nlr OPENBSD_6_4 src/sys/net/pfvar.h
U testdir/pfvar.h
$ cc -o test test.c
$ ./test
Size: 3424
```