### PR TITLE
Fix capturing of local DNS servers

### DIFF
--- a/sshuttle/methods/nat.py
+++ b/sshuttle/methods/nat.py
@@ -54,7 +54,13 @@ class Method(BaseMethod):
         # tunnelling the traffic designated to all local TCP/IP addresses.
         _ipt('-A', chain, '-j', 'RETURN',
              '-m', 'addrtype',
-             '--dst-type', 'LOCAL')
+             '--dst-type', 'LOCAL',
+             '!', '-p', 'udp')
+        # Skip LOCAL traffic if it's not DNS.
+        _ipt('-A', chain, '-j', 'RETURN',
+             '-m', 'addrtype',
+             '--dst-type', 'LOCAL',
+             '-p', 'udp', '!', '--dport', '53')
 
         # create new subnet entries.
         for _, swidth, sexclude, snet, fport, lport \

--- a/tests/client/test_methods_nat.py
+++ b/tests/client/test_methods_nat.py
@@ -140,7 +140,11 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt_ttl, mock_ipt):
         call(AF_INET, 'nat', '-I', 'OUTPUT', '1', '-j', 'sshuttle-1025'),
         call(AF_INET, 'nat', '-I', 'PREROUTING', '1', '-j', 'sshuttle-1025'),
         call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'RETURN',
-             '-m', 'addrtype', '--dst-type', 'LOCAL'),
+             '-m', 'addrtype', '--dst-type', 'LOCAL',
+             '!', '-p', 'udp'),
+        call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'RETURN',
+             '-m', 'addrtype', '--dst-type', 'LOCAL',
+             '-p', 'udp', '!', '--dport', '53'),
         call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'RETURN',
              '--dest', u'1.2.3.66/32', '-p', 'tcp', '--dport', '8080:8080')
     ]


### PR DESCRIPTION
Regression was introduced in #337 that is skipping all local traffic,
including DNS. This change makes UDP port 53 (DNS) LOCAL traffic to be
treated as special case.

Fixes #357