### PR TITLE
Fix crashing on ECONNABORTED

### DIFF
--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -56,7 +56,8 @@ cmd_to_name = {
 NET_ERRS = [errno.ECONNREFUSED, errno.ETIMEDOUT,
             errno.EHOSTUNREACH, errno.ENETUNREACH,
             errno.EHOSTDOWN, errno.ENETDOWN,
-            errno.ENETUNREACH]
+            errno.ENETUNREACH, errno.ECONNABORTED,
+            errno.ECONNRESET]
 
 
 def _add(l, elem):


### PR DESCRIPTION
In certain cases socket.connect fails with ECONNABORTED, which is
treated as "unknown" error causing sshuttle to crash.

Fixes #356