### PR TITLE
Fix broken string substitution from a765aa32

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -197,7 +197,7 @@ class FirewallClient:
         if platform.platform().startswith('OpenBSD'):
             elev_prefix = ['doas']
         else:
-            elev_prefix = ['sudo', '-p', '[local %(eb)s] Password: ']
+            elev_prefix = ['sudo', '-p', '[local sudo] Password: ']
         if sudo_pythonpath:
             elev_prefix += ['/usr/bin/env',
                             'PYTHONPATH=%s' % python_path]


### PR DESCRIPTION
The changes in a765aa32 removed a more complex pieced of code for parsing which sudo command to use. The %(eb)s no longer refers to any variable and is directly printed to the command line.

%(eb)s is now replaced with ‘sudo’.