### PR TITLE
Add option for latency control buffer size

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -189,6 +189,13 @@ Options
     control feature, maximizing bandwidth usage.  Use at
     your own risk.
 
+.. option:: --latency-buffer-size
+
+    Set the size of the buffer used in latency control. The
+    default is ``32768``. Changing this option allows a compromise
+    to be made between latency and bandwidth without completely
+    disabling latency control (with :option:`--no-latency-control`).
+
 .. option:: -D, --daemon
 
     Automatically fork into the background after connecting

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -17,6 +17,9 @@ def main():
     if opt.wrap:
         import sshuttle.ssnet as ssnet
         ssnet.MAX_CHANNEL = opt.wrap
+    if opt.latency_buffer_size:
+        import sshuttle.ssnet as ssnet
+        ssnet.LATENCY_BUFFER_SIZE = opt.latency_buffer_size
     helpers.verbose = opt.verbose
 
     try:

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -244,6 +244,16 @@ parser.add_argument(
     """
 )
 parser.add_argument(
+    "--latency-buffer-size",
+    metavar="SIZE",
+    type=int,
+    default=32768,
+    dest="latency_buffer_size",
+    help="""
+    size of latency control buffer
+    """
+)
+parser.add_argument(
     "--wrap",
     metavar="NUM",
     type=int,

--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -8,6 +8,7 @@ import os
 from sshuttle.helpers import b, binary_type, log, debug1, debug2, debug3, Fatal
 
 MAX_CHANNEL = 65535
+LATENCY_BUFFER_SIZE = 32768
 
 # these don't exist in the socket module in python 2.3!
 SHUT_RD = 0
@@ -368,7 +369,7 @@ class Mux(Handler):
         return total
 
     def check_fullness(self):
-        if self.fullness > 32768:
+        if self.fullness > LATENCY_BUFFER_SIZE:
             if not self.too_full:
                 self.send(0, CMD_PING, b('rttest'))
             self.too_full = True
@@ -448,7 +449,7 @@ class Mux(Handler):
     def fill(self):
         self.rsock.setblocking(False)
         try:
-            read = _nb_clean(os.read, self.rsock.fileno(), 32768)
+            read = _nb_clean(os.read, self.rsock.fileno(), LATENCY_BUFFER_SIZE)
         except OSError:
             _, e = sys.exc_info()[:2]
             raise Fatal('other end: %r' % e)


### PR DESCRIPTION
This commit resolves #297, allowing the buffers used in the latency control to be changed with a command line option ‘--latency-buffer-size’.

We do this by changing a module variable in ssnet.py (similar to the MAX_CHANNEL variable) which seems to be the simplest code change without extensive hacking.

Documentation is also updated.