### PR TITLE
Make hostwatch locale-independent

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -220,6 +220,7 @@ class FirewallClient:
                 if argv[0] == 'su':
                     sys.stderr.write('[local su] ')
                 self.p = ssubprocess.Popen(argv, stdout=s1, preexec_fn=setup)
+                # No env: Talking to `FirewallClient.start`, which has no i18n.
                 e = None
                 break
             except OSError as e:

--- a/sshuttle/hostwatch.py
+++ b/sshuttle/hostwatch.py
@@ -131,7 +131,8 @@ def _check_netstat():
     }
     argv = ['netstat', '-n']
     try:
-        p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null, env=env)
+        p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null,
+                              env=env)
         content = p.stdout.read().decode("ASCII")
         p.wait()
     except OSError:
@@ -149,10 +150,15 @@ def _check_smb(hostname):
     global _smb_ok
     if not _smb_ok:
         return
-    argv = ['smbclient', '-U', '%', '-L', hostname]
     debug2(' > smb: %s\n' % hostname)
+    env = {
+        'PATH': os.environ['PATH'],
+        'LC_ALL': "C",
+    }
+    argv = ['smbclient', '-U', '%', '-L', hostname]
     try:
-        p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null)
+        p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null,
+                              env=env)
         lines = p.stdout.readlines()
         p.wait()
     except OSError:
@@ -207,10 +213,15 @@ def _check_nmb(hostname, is_workgroup, is_master):
     global _nmb_ok
     if not _nmb_ok:
         return
-    argv = ['nmblookup'] + ['-M'] * is_master + ['--', hostname]
     debug2(' > n%d%d: %s\n' % (is_workgroup, is_master, hostname))
+    env = {
+        'PATH': os.environ['PATH'],
+        'LC_ALL': "C",
+    }
+    argv = ['nmblookup'] + ['-M'] * is_master + ['--', hostname]
     try:
-        p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null)
+        p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null,
+                              env=env)
         lines = p.stdout.readlines()
         rv = p.wait()
     except OSError:

--- a/sshuttle/hostwatch.py
+++ b/sshuttle/hostwatch.py
@@ -125,9 +125,13 @@ def _check_dns(hostname):
 
 def _check_netstat():
     debug2(' > netstat\n')
+    env = {
+        'PATH': os.environ['PATH'],
+        'LC_ALL': "C",
+    }
     argv = ['netstat', '-n']
     try:
-        p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null)
+        p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null, env=env)
         content = p.stdout.read().decode("ASCII")
         p.wait()
     except OSError:

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -106,6 +106,7 @@ def _sysctl_set(name, val):
     argv = ['sysctl', '-w', '%s=%s' % (name, val)]
     debug1('>> %s\n' % ' '.join(argv))
     return ssubprocess.call(argv, stdout=open(os.devnull, 'w'))
+    # No env: No output. (Or error that won't be parsed.)
 
 
 _changedctls = []
@@ -139,6 +140,7 @@ def ipfw(*args):
     argv = ['ipfw', '-q'] + list(args)
     debug1('>> %s\n' % ' '.join(argv))
     rv = ssubprocess.call(argv)
+    # No env: No output. (Or error that won't be parsed.)
     if rv:
         raise Fatal('%r returned %d' % (argv, rv))
 
@@ -147,6 +149,7 @@ def ipfw_noexit(*args):
     argv = ['ipfw', '-q'] + list(args)
     debug1('>> %s\n' % ' '.join(argv))
     ssubprocess.call(argv)
+    # No env: No output. (Or error that won't be parsed.)
 
 
 class Method(BaseMethod):

--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -179,6 +179,7 @@ class FreeBsd(Generic):
 
     def enable(self):
         returncode = ssubprocess.call(['kldload', 'pf'])
+        # No env: No output.
         super(FreeBsd, self).enable()
         if returncode == 0:
             _pf_context['loaded_by_sshuttle'] = True
@@ -188,6 +189,7 @@ class FreeBsd(Generic):
         if _pf_context['loaded_by_sshuttle'] and \
                 _pf_context['started_by_sshuttle'] == 0:
             ssubprocess.call(['kldunload', 'pf'])
+            # No env: No output.
 
     def add_anchors(self, anchor):
         status = pfctl('-s all')[0]

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -133,6 +133,7 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
     debug2('executing: %r\n' % argv)
     p = ssubprocess.Popen(argv, stdin=s1a, stdout=s1b, preexec_fn=setup,
                           close_fds=True, stderr=stderr)
+    # No env: Would affect the entire sshuttle.
     os.close(s1a)
     os.close(s1b)
     s2.sendall(content)


### PR DESCRIPTION
See #377: hostwatch used to call netstat and parse the result,
without setting the locale.
The problem is converting the binary output to a unicode string,
as the locale may be utf-8, latin-1, or literally anything.
Setting the locale to C avoids this issue, as netstat's source
strings to not use non-ASCII characters.