### PR TITLE
Simplify nftables based method

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -44,7 +44,7 @@ Options
     to during startup will be routed over the VPN. Valid examples are
     example.com, example.com:8000 and example.com:8000-9000.
 
-.. option:: --method [auto|nat|tproxy|pf]
+.. option:: --method [auto|nat|nft|tproxy|pf]
 
    Which firewall method should sshuttle use? For auto, sshuttle attempts to
    guess the appropriate method depending on what it can find in PATH. The

--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -1,8 +1,6 @@
-import re
 import os
 import socket
 import subprocess as ssubprocess
-
 from sshuttle.helpers import log, debug1, Fatal, family_to_string
 
 
@@ -52,10 +50,8 @@ def ipt(family, table, *args):
 
 
 def nft(family, table, action, *args):
-    if family == socket.AF_INET:
-        argv = ['nft', action, 'ip', table] + list(args)
-    elif family == socket.AF_INET6:
-        argv = ['nft', action, 'ip6', table] + list(args)
+    if family in (socket.AF_INET, socket.AF_INET6):
+        argv = ['nft', action, 'inet', table] + list(args)
     else:
         raise Exception('Unsupported family "%s"' % family_to_string(family))
     debug1('>> %s\n' % ' '.join(argv))
@@ -66,48 +62,6 @@ def nft(family, table, action, *args):
     rv = ssubprocess.call(argv, env=env)
     if rv:
         raise Fatal('%r returned %d' % (argv, rv))
-
-
-def nft_chain_exists(family, table, name):
-    if family == socket.AF_INET:
-        fam = 'ip'
-    elif family == socket.AF_INET6:
-        fam = 'ip6'
-    else:
-        raise Exception('Unsupported family "%s"' % family_to_string(family))
-    argv = ['nft', 'list', 'chain', fam, table, name]
-    debug1('>> %s\n' % ' '.join(argv))
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
-    try:
-        table_exists = False
-        output = ssubprocess.check_output(argv, env=env,
-                                          stderr=ssubprocess.STDOUT)
-        for line in output.decode('ASCII').split('\n'):
-            if line.startswith('table %s %s ' % (fam, table)):
-                table_exists = True
-            if table_exists and ('chain %s {' % name) in line:
-                return True
-    except ssubprocess.CalledProcessError:
-        return False
-
-
-def nft_get_handle(expression, chain):
-    cmd = 'nft'
-    argv = [cmd, 'list', expression, '-a']
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
-    try:
-        output = ssubprocess.check_output(argv, env=env)
-        for line in output.decode('utf-8').split('\n'):
-            if ('jump %s' % chain) in line:
-                return re.sub('.*# ', '', line)
-    except ssubprocess.CalledProcessError as e:
-        raise Fatal('%r returned %d' % (argv, e.returncode))
 
 
 _no_ttl_module = False


### PR DESCRIPTION
This simplifies the nft based method: it creates a table for all the sshuttle rules, which then can be deleted by an one-liner and hence the `nft_get_handle` function is gotten rid of.