### PR TITLE
Run all systemd notifications from main process

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -87,7 +87,6 @@ Additional Suggested Software
    
    [Service]
    Type=notify
-   NotifyAccess=all
    ExecStart=/usr/bin/sshuttle --dns --remote <user>@<server> <subnets...>
    
    [Install]

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -11,6 +11,7 @@ import sshuttle.helpers as helpers
 import sshuttle.ssnet as ssnet
 import sshuttle.ssh as ssh
 import sshuttle.ssyslog as ssyslog
+import sshuttle.sdnotify as sdnotify
 from sshuttle.ssnet import SockWrapper, Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import log, debug1, debug2, debug3, Fatal, islocal, \
     resolvconf_nameservers
@@ -518,6 +519,8 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
         # ignore its contents.
         mux.got_routes = None
         fw.start()
+        sdnotify.send(sdnotify.ready(), sdnotify.status('Connected'))
+
     mux.got_routes = onroutes
 
     def onhostlist(hostlist):
@@ -798,6 +801,8 @@ def main(listenip_v6, listenip_v4,
                 # it's not our child anymore; can't waitpid
                 fw.p.returncode = 0
             fw.done()
+            sdnotify.send(sdnotify.stop())
+
         finally:
             if daemon:
                 daemon_cleanup()

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -518,10 +518,13 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
         # set --auto-nets, we might as well wait for the message first, then
         # ignore its contents.
         mux.got_routes = None
-        fw.start()
-        sdnotify.send(sdnotify.ready(), sdnotify.status('Connected'))
+        serverready()
 
     mux.got_routes = onroutes
+
+    def serverready():
+        fw.start()
+        sdnotify.send(sdnotify.ready(), sdnotify.status('Connected'))
 
     def onhostlist(hostlist):
         debug2('got host list: %r\n' % hostlist)

--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -7,7 +7,6 @@ import platform
 import traceback
 
 import sshuttle.ssyslog as ssyslog
-import sshuttle.sdnotify as sdnotify
 from sshuttle.helpers import debug1, debug2, Fatal
 from sshuttle.methods import get_auto_method, get_method
 
@@ -220,8 +219,6 @@ def main(method_name, syslog):
                 user)
 
         stdout.write('STARTED\n')
-        sdnotify.send(sdnotify.ready(),
-                      sdnotify.status('Connected'))
 
         try:
             stdout.flush()
@@ -247,7 +244,6 @@ def main(method_name, syslog):
                 break
     finally:
         try:
-            sdnotify.send(sdnotify.stop())
             debug1('firewall manager: undoing changes.\n')
         except BaseException:
             debug2('An error occurred, ignoring it.')


### PR DESCRIPTION
I decided to try bringing all the notifications into the primary process to address #402.

Testing indicates these notification changes work fine, so long as `sshuttle` is either directly invoked by ExecStart or, with a shell-script invoked in ExecStart, by using `exec sshuttle ...`.  Otherwise, `NotifyAccess` hackery becomes useful. 

I'm not completely satisfied with this, as placing the confirmation code in the onroutes callback is a little funny.  It seems like the "Connected" indication sent to systemd actually happens before we have a confirmed connection, too.  That said, I'm not seeing any better (working) place for it, not being deeply familiar with the code; and "working" is good.  Better recommendation would certainly be welcome.
