### PR TITLE
Add 'My VPN broke and need a solution fast' to the docs.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -20,6 +20,11 @@ Forward all traffic::
 
       sshuttle -r username@sshserver 0/0
 
+
+- For 'My VPN broke and need a temporary solution FAST to access local IPv4 addresses': 
+
+      sshuttle --dns -NHr username@sshserver 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+
 If you would also like your DNS queries to be proxied
 through the DNS server of the server you are connect to::
 


### PR DESCRIPTION
I wish I had that in the docs when the VPN broke, needed access to a machine asap and needed things to just work for a moment.

It's the 'smart VPN', only forwarding traffic what's made to local IPv4 addresses. Thus making normal browsing for other documentation faster.

Source: https://en.wikipedia.org/wiki/Private_network#Private_IPv4_addresses