### PR TITLE
Fix Python 3.8 file operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,14 @@ language: python
 
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: pypy
-      env: TOXENV=pypy
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
 
 install:
   - pip install tox

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -6,7 +6,7 @@ Client side Requirements
 
 - sudo, or root access on your client machine.
   (The server doesn't need admin access.)
-- Python 2.7 or Python 3.5.
+- Python 3.5 or greater.
 
 
 Linux with NAT method
@@ -31,14 +31,6 @@ Supports:
 * IPv6 TCP
 * IPv6 UDP (requires ``recvmsg`` - see below)
 * IPv6 DNS (requires ``recvmsg`` - see below)
-
-.. _PyXAPI: http://www.pps.univ-paris-diderot.fr/~ylg/PyXAPI/
-
-Full UDP or DNS support with the TPROXY method requires the ``recvmsg()``
-syscall. This is not available in Python 2, however it is in Python 3.5 and
-later. Under Python 2 you might find it sufficient to install PyXAPI_ in
-order to get the ``recvmsg()`` function. See :doc:`tproxy` for more
-information.
 
 
 MacOS / FreeBSD / OpenBSD / pfSense

--- a/run
+++ b/run
@@ -7,8 +7,6 @@ python_best_version() {
   if [ -x "$(command -v python3)" ] &&
       python3 -c "import sys; sys.exit(not sys.version_info > (3, 5))"; then
     exec python3 "$@"
-  elif [ -x "$(command -v python2.7)" ]; then
-    exec python2.7 "$@"
   else
     exec python "$@"
   fi

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,10 @@ setup(
         "License :: OSI Approved :: "
             "GNU Lesser General Public License v2 or later (LGPLv2+)",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: System :: Networking",
     ],
     scripts=['bin/sudoers-add'],

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -461,7 +461,7 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
             raise Fatal("failed to establish ssh session (1)")
         else:
             raise
-    mux = Mux(serversock, serversock)
+    mux = Mux(serversock.makefile("rb"), serversock.makefile("wb"))
     handlers.append(mux)
 
     expected = b'SSHUTTLE0001'

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -294,10 +294,7 @@ def main(latency_control, auto_hosts, to_nameserver, auto_nets):
     sys.stdout.flush()
 
     handlers = []
-    mux = Mux(socket.fromfd(sys.stdin.fileno(),
-                            socket.AF_INET, socket.SOCK_STREAM),
-              socket.fromfd(sys.stdout.fileno(),
-                            socket.AF_INET, socket.SOCK_STREAM))
+    mux = Mux(sys.stdin, sys.stdout)
     handlers.append(mux)
 
     debug1('auto-nets:' + str(auto_nets) + '\n')

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,16 @@
 [tox]
 downloadcache = {toxworkdir}/cache/
 envlist =
-    py27,
-    py34,
     py35,
     py36,
-    pypy,
+    py37,
+    py38,
 
 [testenv]
 basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
     py36: python3.6
-    pypy: pypy
+    py37: python3.7
+    py38: python3.8
 commands =
     pip install -e .
     # actual flake8 test


### PR DESCRIPTION
Under Python 3.8 we can not wrap a File in a Sock.

Note this currently requires Python >= 3.5