### PR TITLE
ref: WIP replace usage of deprecated imp

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -1,6 +1,6 @@
 import sys
 import zlib
-import imp
+import types
 
 verbosity = verbosity  # noqa: F821 must be a previously defined global
 z = zlib.decompressobj()
@@ -15,7 +15,7 @@ while 1:
                              % (name, nbytes))
         content = z.decompress(sys.stdin.read(nbytes))
 
-        module = imp.new_module(name)
+        module = types.ModuleType(name)
         parents = name.rsplit(".", 1)
         if len(parents) == 2:
             parent, parent_name = parents


### PR DESCRIPTION
sshuttle yells about `DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses`. It's been deprecated since 3.4, and I see there isn't any intention supporting <3.4 based on https://github.com/sshuttle/sshuttle/pull/431.