### PR TITLE
chore: remove branching related to python < 3.5

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -228,12 +228,7 @@ class FirewallClient:
                 pass
         self.argv = argv
         s1.close()
-        if sys.version_info < (3, 0):
-            # python 2.7
-            self.pfile = s2.makefile('wb+')
-        else:
-            # python 3.5
-            self.pfile = s2.makefile('rwb')
+        self.pfile = s2.makefile('rwb')
         if e:
             log('Spawning firewall manager: %r\n' % self.argv)
             raise Fatal(e)

--- a/sshuttle/helpers.py
+++ b/sshuttle/helpers.py
@@ -5,8 +5,6 @@ import errno
 logprefix = ''
 verbose = 0
 
-binary_type = bytes
-
 
 def b(s):
     return s.encode("ASCII")

--- a/sshuttle/helpers.py
+++ b/sshuttle/helpers.py
@@ -5,16 +5,11 @@ import errno
 logprefix = ''
 verbose = 0
 
-if sys.version_info[0] == 3:
-    binary_type = bytes
+binary_type = bytes
 
-    def b(s):
-        return s.encode("ASCII")
-else:
-    binary_type = str
 
-    def b(s):
-        return s
+def b(s):
+    return s.encode("ASCII")
 
 
 def log(s):

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -6,6 +6,7 @@ import time
 import sys
 import os
 import platform
+from shutil import which
 
 import sshuttle.ssnet as ssnet
 import sshuttle.helpers as helpers
@@ -14,11 +15,6 @@ import subprocess as ssubprocess
 from sshuttle.ssnet import Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import b, log, debug1, debug2, debug3, Fatal, \
     resolvconf_random_nameserver
-
-try:
-    from shutil import which
-except ImportError:
-    from distutils.spawn import find_executable as which
 
 
 def _ipmatch(ipstr):

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -6,23 +6,12 @@ import zlib
 import imp
 import subprocess as ssubprocess
 import shlex
+from shlex import quote
 import ipaddress
-
-# ensure backwards compatiblity with python2.7
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
+from urllib.parse import urlparse
 
 import sshuttle.helpers as helpers
 from sshuttle.helpers import debug2
-
-try:
-    # Python >= 3.5
-    from shlex import quote
-except ImportError:
-    # Python 2.x
-    from pipes import quote
 
 
 def readfile(name):

--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -5,7 +5,7 @@ import errno
 import select
 import os
 
-from sshuttle.helpers import b, binary_type, log, debug1, debug2, debug3, Fatal
+from sshuttle.helpers import b, log, debug1, debug2, debug3, Fatal
 
 MAX_CHANNEL = 65535
 LATENCY_BUFFER_SIZE = 32768
@@ -382,7 +382,7 @@ class Mux(Handler):
         # log('outbuf: %d %r\n' % (self.amount_queued(), ob))
 
     def send(self, channel, cmd, data):
-        assert isinstance(data, binary_type)
+        assert isinstance(data, bytes)
         assert len(data) <= 65535
         p = struct.pack('!ccHHH', b('S'), b('S'), channel, cmd, len(data)) \
             + data

--- a/tests/client/test_helpers.py
+++ b/tests/client/test_helpers.py
@@ -1,4 +1,3 @@
-import sys
 import io
 import socket
 from socket import AF_INET, AF_INET6
@@ -193,9 +192,5 @@ def test_family_ip_tuple():
 def test_family_to_string():
     assert sshuttle.helpers.family_to_string(AF_INET) == "AF_INET"
     assert sshuttle.helpers.family_to_string(AF_INET6) == "AF_INET6"
-    if sys.version_info < (3, 0):
-        expected = "1"
-        assert sshuttle.helpers.family_to_string(socket.AF_UNIX) == "1"
-    else:
-        expected = 'AddressFamily.AF_UNIX'
+    expected = 'AddressFamily.AF_UNIX'
     assert sshuttle.helpers.family_to_string(socket.AF_UNIX) == expected

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,6 @@
 import sys
 
-if sys.version_info >= (3, 0):
-    good_python = sys.version_info >= (3, 5)
-else:
-    good_python = sys.version_info >= (2, 7)
+good_python = sys.version_info >= (3, 5)
 
 collect_ignore = []
 if not good_python:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,0 @@
-import sys
-
-good_python = sys.version_info >= (3, 5)
-
-collect_ignore = []
-if not good_python:
-    collect_ignore.append("client")


### PR DESCRIPTION
I see there isn't any intention supporting < 3.5 per https://github.com/sshuttle/sshuttle/pull/431, so here's a little branching cleanup.