### PR TITLE
chore: suppress imp DeprecationWarning

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -1,6 +1,10 @@
 import sys
 import zlib
-import imp
+import warnings
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import imp
 
 verbosity = verbosity  # noqa: F821 must be a previously defined global
 z = zlib.decompressobj()

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -3,15 +3,19 @@ import os
 import re
 import socket
 import zlib
-import imp
 import subprocess as ssubprocess
 import shlex
 from shlex import quote
 import ipaddress
 from urllib.parse import urlparse
+import warnings
 
 import sshuttle.helpers as helpers
 from sshuttle.helpers import debug2
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import imp
 
 
 def readfile(name):


### PR DESCRIPTION
I briefly attempted to port usage of `imp` over in https://github.com/sshuttle/sshuttle/pull/449, but it turned out to be nontrivial.

In the future you'll want to either finish the port, or restrict python versions to whenever `imp` will be removed.