### PR TITLE
fix connection with @ sign in username

### DIFF
--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -76,9 +76,8 @@ def parse_hostport(rhostport):
 
     if "@" in host:
         # split username (and possible password) from the host[:port]
-        username, host = host.split("@")
+        username, host = host.rsplit("@", 1)
         # Fix #410 bad username error detect
-        # username cannot contain an @ sign in this scenario
         if ":" in username:
             # this will even allow for the username to be empty
             username, password = username.split(":")


### PR DESCRIPTION
Issue: https://github.com/sshuttle/sshuttle/issues/458

currently sshuttle fails if username contains `@`

```
Traceback (most recent call last):
  File "/usr/local/bin/sshuttle", line 11, in <module>
    load_entry_point('sshuttle==1.0.1', 'console_scripts', 'sshuttle')()
  File "/usr/local/Cellar/sshuttle/1.0.1/libexec/lib/python3.8/site-packages/sshuttle/cmdline.py", line 85, in main
    return_code = client.main(ipport_v6, ipport_v4,
  File "/usr/local/Cellar/sshuttle/1.0.1/libexec/lib/python3.8/site-packages/sshuttle/client.py", line 793, in main
    return _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
  File "/usr/local/Cellar/sshuttle/1.0.1/libexec/lib/python3.8/site-packages/sshuttle/client.py", line 447, in _main
    (serverproc, serversock) = ssh.connect(
  File "/usr/local/Cellar/sshuttle/1.0.1/libexec/lib/python3.8/site-packages/sshuttle/ssh.py", line 113, in connect
    username, password, port, host = parse_hostport(rhostport)
  File "/usr/local/Cellar/sshuttle/1.0.1/libexec/lib/python3.8/site-packages/sshuttle/ssh.py", line 79, in parse_hostport
    username, host = host.split("@")
ValueError: too many values to unpack (expected 2)
```

```
In [1]: host = 'user@name.com@example.com'
In [2]: username, host = host.split("@")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-23bb0f0321bc> in <module>
----> 1 username, host = host.split("@")
ValueError: too many values to unpack (expected 2)
In [3]:
```
introduced in https://github.com/sshuttle/sshuttle/commit/966fd0c5231d56c4f464752865d96f97bd3c0aac#diff-8d7b1e96a737eb7011e2012d5d797916R90 

this change will split username and host in this way:

```
In [1]: host = 'user@name.com@example.com'

In [2]: host.rsplit("@",1)
Out[2]: ['user@name.com', 'example.com']

```
