### PR TITLE
Restrict setuptools from executing on Python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
             'sshuttle = sshuttle.cmdline:main',
         ],
     },
+    python_requires='>=3.5',
     tests_require=[
         'pytest',
         'pytest-cov',


### PR DESCRIPTION
python_requires will be evaluated by setuptools to ensure the package is compatible
with currently active Python interpreter.

Reference: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires

Closes #470

Signed-off-by: Wilson Husin <wilsonehusin@gmail.com>