### PR TITLE
Should ensure rhost is always a string

### DIFF
--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -87,7 +87,7 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
     if username:
         rhost = "{}@{}".format(username, host)
     else:
-        rhost = host
+        rhost = str(host)
 
     z = zlib.compressobj(1)
     content = get_module_source('sshuttle.assembler')


### PR DESCRIPTION
This would fix the issue described in https://github.com/sshuttle/sshuttle/issues/488 where a connection can't be established unless a username is specified for remote host.