### PR TITLE
Douglas Adams and Deep Thought was wrong, 42 is not the answer

### DIFF
--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -71,10 +71,10 @@ def ipt_ttl(family, *args):
     global _no_ttl_module
     if not _no_ttl_module:
         # we avoid infinite loops by generating server-side connections
-        # with ttl 42.  This makes the client side not recapture those
+        # with ttl 63.  This makes the client side not recapture those
         # connections, in case client == server.
         try:
-            argsplus = list(args) + ['-m', 'ttl', '!', '--ttl', '42']
+            argsplus = list(args) + ['-m', 'ttl', '!', '--ttl', '63']
             ipt(family, *argsplus)
         except Fatal:
             ipt(family, *args)

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -70,7 +70,7 @@ def ipfw_rule_exists(n):
     found = False
     for line in p.stdout:
         if line.startswith(b'%05d ' % n):
-            if not ('ipttl 42' in line or 'check-state' in line):
+            if not ('ipttl 63' in line or 'check-state' in line):
                 log('non-sshuttle ipfw rule: %r\n' % line.strip())
                 raise Fatal('non-sshuttle ipfw rule #%d already exists!' % n)
             found = True
@@ -185,7 +185,7 @@ class Method(BaseMethod):
         sender.setsockopt(socket.SOL_IP, IP_BINDANY, 1)
         sender.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sender.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-        sender.setsockopt(socket.SOL_IP, socket.IP_TTL, 42)
+        sender.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)
         sender.bind(srcip)
         sender.sendto(data, dstip)
         sender.close()
@@ -224,7 +224,7 @@ class Method(BaseMethod):
         ipfw('add', '1', 'fwd', '127.0.0.1,%d' % port,
              'tcp',
              'from', 'any', 'to', 'table(126)',
-             'not', 'ipttl', '42', 'keep-state', 'setup')
+             'not', 'ipttl', '63', 'keep-state', 'setup')
 
         ipfw_noexit('table', '124', 'flush')
         dnscount = 0
@@ -235,11 +235,11 @@ class Method(BaseMethod):
             ipfw('add', '1', 'fwd', '127.0.0.1,%d' % dnsport,
                  'udp',
                  'from', 'any', 'to', 'table(124)',
-                 'not', 'ipttl', '42')
+                 'not', 'ipttl', '63')
         ipfw('add', '1', 'allow',
              'udp',
              'from', 'any', 'to', 'any',
-             'ipttl', '42')
+             'ipttl', '63')
 
         if subnets:
             # create new subnet entries

--- a/sshuttle/methods/nft.py
+++ b/sshuttle/methods/nft.py
@@ -50,17 +50,17 @@ class Method(BaseMethod):
                      'ip daddr %s/%s' % (snet, swidth), 'return')))
             else:
                 _nft('add rule', chain, *(tcp_ports + (
-                     'ip daddr %s/%s' % (snet, swidth), 'ip ttl != 42',
+                     'ip daddr %s/%s' % (snet, swidth), 'ip ttl != 63',
                      ('redirect to :' + str(port)))))
 
         for _, ip in [i for i in nslist if i[0] == family]:
             if family == socket.AF_INET:
                 _nft('add rule', chain, 'ip protocol udp ip daddr %s' % ip,
-                     'udp dport { 53 }', 'ip ttl != 42',
+                     'udp dport { 53 }', 'ip ttl != 63',
                      ('redirect to :' + str(dnsport)))
             elif family == socket.AF_INET6:
                 _nft('add rule', chain, 'ip6 protocol udp ip6 daddr %s' % ip,
-                     'udp dport { 53 }', 'ip ttl != 42',
+                     'udp dport { 53 }', 'ip ttl != 63',
                      ('redirect to :' + str(dnsport)))
 
     def restore_firewall(self, port, family, udp, user):

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -195,7 +195,7 @@ class DnsProxy(Handler):
 
         family, sockaddr = self._addrinfo(peer, port)
         sock = socket.socket(family, socket.SOCK_DGRAM)
-        sock.setsockopt(socket.SOL_IP, socket.IP_TTL, 42)
+        sock.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)
         sock.connect(sockaddr)
 
         self.peers[sock] = peer
@@ -252,7 +252,7 @@ class UdpProxy(Handler):
         self.chan = chan
         self.sock = sock
         if family == socket.AF_INET:
-            self.sock.setsockopt(socket.SOL_IP, socket.IP_TTL, 42)
+            self.sock.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)
 
     def send(self, dstip, data):
         debug2('UDP: sending to %r port %d\n' % dstip)

--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -570,7 +570,7 @@ class MuxWrapper(SockWrapper):
 def connect_dst(family, ip, port):
     debug2('Connecting to %s:%d\n' % (ip, port))
     outsock = socket.socket(family)
-    outsock.setsockopt(socket.SOL_IP, socket.IP_TTL, 42)
+    outsock.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)
     return SockWrapper(outsock, outsock,
                        connect_to=(ip, port),
                        peername='%s:%d' % (ip, port))


### PR DESCRIPTION
It might come as a surprise but some cross-region connections between AWS us-east-1 and AWS us-west-2 are currently routing through more than 42 hops. I might be wrong but if we can set the IP4 TTL to any non-default number 63 might be a better choice to get us close to the Linux default of 64?