### PR TITLE
Fix doc about --listen option

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -65,7 +65,8 @@ Options
     :program:`sshuttle`, e.g. ``--listen localhost``.
 
     For the tproxy and pf methods this can be an IPv6 address. Use this option 
-    with comma separated values if required, to provide both IPv4 and IPv6 addresses, e.g. ``--listen 127.0.0.1:0,[::1]:0``.
+    with comma separated values if required, to provide both IPv4 and IPv6
+    addresses, e.g. ``--listen 127.0.0.1:0,[::1]:0``.
 
 .. option:: -H, --auto-hosts
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -65,7 +65,7 @@ Options
     :program:`sshuttle`, e.g. ``--listen localhost``.
 
     For the tproxy and pf methods this can be an IPv6 address. Use this option 
-    twice if required, to provide both IPv4 and IPv6 addresses.
+    with comma separated values if required, to provide both IPv4 and IPv6 addresses, e.g. ``--listen 127.0.0.1:0,[::1]:0``.
 
 .. option:: -H, --auto-hosts
 


### PR DESCRIPTION
This PR provides correct document about --listen option probably.
(I don't know about tproxy and pf methods, so I'm not sure this change is right.)

Current document is this:

>    For the tproxy and pf methods this can be an IPv6 address. Use this option
    twice if required, to provide both IPv4 and IPv6 addresses.
https://github.com/sshuttle/sshuttle/blob/5bdf36152ab9302eada49ead7a106d2dc666b9c5/docs/manpage.rst

But the code didn't seem to be doing that.

https://github.com/sshuttle/sshuttle/blob/5bdf36152ab9302eada49ead7a106d2dc666b9c5/sshuttle/cmdline.py#L65-L79
