### PR TITLE
fix: require -r/--remote

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -557,6 +557,11 @@ def main(listenip_v6, listenip_v4,
          subnets_include, subnets_exclude, daemon, to_nameserver, pidfile,
          user, sudo_pythonpath):
 
+    if not remotename:
+        # XXX: We can't make it required at the argparse level,
+        #      because sshuttle calls out to itself in FirewallClient.
+        raise Fatal("You must specify -r/--remote.")
+
     if daemon:
         try:
             check_daemon(pidfile)

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -177,6 +177,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "-r", "--remote",
+    required=True,
     metavar="[USERNAME[:PASSWORD]@]ADDR[:PORT]",
     help="""
     ssh hostname (and optional username and password) of remote %(prog)s server

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -177,7 +177,6 @@ parser.add_argument(
 )
 parser.add_argument(
     "-r", "--remote",
-    required=True,
     metavar="[USERNAME[:PASSWORD]@]ADDR[:PORT]",
     help="""
     ssh hostname (and optional username and password) of remote %(prog)s server


### PR DESCRIPTION
Fixes https://github.com/sshuttle/sshuttle/issues/455.

Before, as the issue describes:

```
$ sshuttle -v --ssh-cmd 'ssh example.com' 0/0
...
    if "@" in host:
TypeError: argument of type 'NoneType' is not iterable
```

This manifests much more horribly in versions before Python 2 support was removed btw. Just some fun trivia. Example `sshuttle==0.78.5` with Python 3 interpreter:

```
sshuttle -v --ssh-cmd 'ssh -i ~/.ssh/example (example ip address)' 192.168.208.0/20 172.16.0.16/28 10.1.128.0/19 10.1.64.0/18 10.1.0.0/18
Starting sshuttle proxy.
-- snip --
Starting client with Python version 3.8.3
c : connecting to server...
assembler.py:3: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
Starting server with Python version 3.8.3
-- snip --
c : Accept TCP: 192.168.42.65:56955 -> 192.168.208.10:22.
c : Accept TCP: 192.168.42.65:56956 -> 192.168.208.10:22.
c : Accept TCP: 192.168.42.65:56957 -> 192.168.208.10:22.
c : Accept TCP: 192.168.42.65:56958 -> 192.168.208.10:22.
c : Accept TCP: 192.168.42.65:56959 -> 192.168.208.10:22.
c : Accept TCP: 192.168.42.65:56960 -> 192.168.208.10:22.
...
```

After:

```
$ sshuttle -v --ssh-cmd 'ssh example.com' 0/0
usage: sshuttle [-l [ip:]port] [-r [user@]sshserver[:port]] <subnets...>
sshuttle: error: the following arguments are required: -r/--remote
```