### PR TITLE
Fix parse_hostport to always return string for host

### DIFF
--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -65,12 +65,12 @@ def parse_hostport(rhostport):
         try:
             # try to parse host as an IP adress,
             # if that works it is an IPv6 address
-            host = ipaddress.ip_address(host)
+            host = str(ipaddress.ip_address(host))
         except ValueError:
             # if that fails parse as URL to get the port
             parsed = urlparse('//{}'.format(host))
             try:
-                host = ipaddress.ip_address(parsed.hostname)
+                host = str(ipaddress.ip_address(parsed.hostname))
             except ValueError:
                 # else if both fails, we have a hostname with port
                 host = parsed.hostname

--- a/tests/ssh/test_parse_hostport.py
+++ b/tests/ssh/test_parse_hostport.py
@@ -1,0 +1,20 @@
+from sshuttle.ssh import parse_hostport
+
+
+def test_host_only():
+    assert parse_hostport("host") == (None, None, None, "host")
+    assert parse_hostport("1.2.3.4") == (None, None, None, "1.2.3.4")
+    assert parse_hostport("2001::1") == (None, None, None, "2001::1")
+    assert parse_hostport("[2001::1]") == (None, None, None, "2001::1")
+
+
+def test_host_and_port():
+    assert parse_hostport("host:22") == (None, None, 22, "host")
+    assert parse_hostport("1.2.3.4:22") == (None, None, 22, "1.2.3.4")
+    assert parse_hostport("[2001::1]:22") == (None, None, 22, "2001::1")
+
+
+def test_username_and_host():
+    assert parse_hostport("user@host") == ("user", None, None, "host")
+    assert parse_hostport("user:@host") == ("user", None, None, "host")
+    assert parse_hostport("user:pass@host") == ("user", "pass", None, "host")


### PR DESCRIPTION
This fixes #488 and provides an alternative solution for #489.