### PR TITLE
Fix python2 server compatibility

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -7,8 +7,11 @@ z = zlib.decompressobj()
 while 1:
     name = sys.stdin.readline().strip()
     if name:
-        name = name.decode("ASCII")
-
+        # python2 compat: in python2 sys.stdin.readline().strip() -> str
+        #                 in python3 sys.stdin.readline().strip() -> bytes
+        # (see #481)
+        if sys.version_info >= (3, 0):
+            name = name.decode("ASCII")
         nbytes = int(sys.stdin.readline())
         if verbosity >= 2:
             sys.stderr.write('server: assembling %r (%d bytes)\n'

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -299,8 +299,8 @@ class FirewallClient:
             raise Fatal('%r expected STARTED, got %r' % (self.argv, line))
 
     def sethostip(self, hostname, ip):
-        assert(not re.search(rb'[^-\w\.]', hostname))
-        assert(not re.search(rb'[^0-9.]', ip))
+        assert(not re.search(br'[^-\w\.]', hostname))
+        assert(not re.search(br'[^0-9.]', ip))
         self.pfile.write(b'HOST %s,%s\n' % (hostname, ip))
         self.pfile.flush()
 

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -20,8 +20,8 @@ else:
         else:
             search_paths = os.defpath.split(os.pathsep)
 
-        for path in search_paths:
-            filepath = os.path.join(path, file)
+        for p in search_paths:
+            filepath = os.path.join(p, file)
             if os.path.exists(filepath) and os.access(filepath, mode):
                 return filepath
         return None

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -6,7 +6,24 @@ import time
 import sys
 import os
 import platform
-from shutil import which
+
+if sys.version_info >= (3, 0):
+    from shutil import which
+else:
+    # python2 compat: shutil.which is not available so we provide our own which command
+    def which(file, mode=os.F_OK | os.X_OK, path=None):
+        if path is not None:
+            search_paths = [path]
+        elif "PATH" in os.environ:
+            search_paths = os.environ["PATH"].split(os.pathsep)
+        else:
+            search_paths = os.defpath.split(os.pathsep)
+
+        for path in search_paths:
+            filepath = os.path.join(path, file)
+            if os.path.exists(filepath) and os.access(filepath, mode):
+                return filepath
+        return None
 
 import sshuttle.ssnet as ssnet
 import sshuttle.helpers as helpers

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -10,7 +10,8 @@ import platform
 if sys.version_info >= (3, 0):
     from shutil import which
 else:
-    # python2 compat: shutil.which is not available so we provide our own which command
+    # python2 compat: shutil.which is not available so we provide our
+    # own which command
     def which(file, mode=os.F_OK | os.X_OK, path=None):
         if path is not None:
             search_paths = [path]


### PR DESCRIPTION
Fixes  #469. We replace python3 exclusive code with a check for python3 and a compatibility fix. Note that the switch from os.set_nonblocking to fcntl.fcntl in 98d052d (fixing #503) also fixes python2 compatibility.

@brianmay I don't know if you like where I put the definition of the 'which' function. Maybe that should be moved? I think the changes are relatively minor and fix python2 compatibility with the server. 

sshuttle is now working for my with a python2 server, but I only have a single setup I can test. Could you or someone else test with a python3 server?

I marked the compatibility code with `#python2 compat` comments to make it clear in the future.