### PR TITLE
Add psutil as dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,9 @@ setup(
         ],
     },
     python_requires='>=3.5',
+    install_requires=[
+        'psutil',
+    ],
     tests_require=[
         'pytest',
         'pytest-cov',


### PR DESCRIPTION
#520 Introduced `psutil` as a dependency but was never added to the setup.py which breaks installations performed from source. Small PR here to address that.