### PR TITLE
Allow no remote to work.

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -572,9 +572,9 @@ def main(listenip_v6, listenip_v4,
          user, sudo_pythonpath):
 
     if not remotename:
-        # XXX: We can't make it required at the argparse level,
-        #      because sshuttle calls out to itself in FirewallClient.
-        raise Fatal("You must specify -r/--remote.")
+        print("WARNING: You must specify -r/--remote to securely route "
+              "traffic to a remote machine. Running without -r/--remote "
+              "is only recommended for testing.")
 
     if daemon:
         try:

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -43,6 +43,8 @@ def parse_hostport(rhostport):
     """
     # leave use of default port to ssh command to prevent overwriting
     # ports configured in ~/.ssh/config when no port is given
+    if rhostport is None or len(rhostport) == 0:
+        return None, None, None, None
     port = None
     username = None
     password = None


### PR DESCRIPTION
Pull request #502 (issue #455) made -r/--remote required. However, the
documentation still indicates that using no remote is a valid way to
test sshuttle (see Examples section of man page). I think this mode
might be useful for testing performance local without ssh, local with
ssh, and remote with ssh.

This patch adds a warning when -r/--remote is missing but restores the
previous behavior.