### PR TITLE
Improve consistency of PATH, environments, and which()

### DIFF
--- a/sshuttle/hostwatch.py
+++ b/sshuttle/hostwatch.py
@@ -9,7 +9,7 @@ import platform
 
 import subprocess as ssubprocess
 import sshuttle.helpers as helpers
-from sshuttle.helpers import log, debug1, debug2, debug3
+from sshuttle.helpers import log, debug1, debug2, debug3, get_env
 
 POLL_TIME = 60 * 15
 NETSTAT_POLL_TIME = 30
@@ -125,14 +125,10 @@ def _check_dns(hostname):
 
 def _check_netstat():
     debug2(' > netstat\n')
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
     argv = ['netstat', '-n']
     try:
         p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null,
-                              env=env)
+                              env=get_env())
         content = p.stdout.read().decode("ASCII")
         p.wait()
     except OSError:
@@ -151,14 +147,10 @@ def _check_smb(hostname):
     if not _smb_ok:
         return
     debug2(' > smb: %s\n' % hostname)
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
     argv = ['smbclient', '-U', '%', '-L', hostname]
     try:
         p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null,
-                              env=env)
+                              env=get_env())
         lines = p.stdout.readlines()
         p.wait()
     except OSError:
@@ -214,14 +206,10 @@ def _check_nmb(hostname, is_workgroup, is_master):
     if not _nmb_ok:
         return
     debug2(' > n%d%d: %s\n' % (is_workgroup, is_master, hostname))
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
     argv = ['nmblookup'] + ['-M'] * is_master + ['--', hostname]
     try:
         p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, stderr=null,
-                              env=env)
+                              env=get_env)
         lines = p.stdout.readlines()
         rv = p.wait()
     except OSError:

--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -1,7 +1,6 @@
-import os
 import socket
 import subprocess as ssubprocess
-from sshuttle.helpers import log, debug1, Fatal, family_to_string
+from sshuttle.helpers import log, debug1, Fatal, family_to_string, get_env
 
 
 def nonfatal(func, *args):
@@ -19,12 +18,8 @@ def ipt_chain_exists(family, table, name):
     else:
         raise Exception('Unsupported family "%s"' % family_to_string(family))
     argv = [cmd, '-t', table, '-nL']
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
     try:
-        output = ssubprocess.check_output(argv, env=env)
+        output = ssubprocess.check_output(argv, env=get_env())
         for line in output.decode('ASCII').split('\n'):
             if line.startswith('Chain %s ' % name):
                 return True
@@ -40,11 +35,7 @@ def ipt(family, table, *args):
     else:
         raise Exception('Unsupported family "%s"' % family_to_string(family))
     debug1('%s\n' % ' '.join(argv))
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
-    rv = ssubprocess.call(argv, env=env)
+    rv = ssubprocess.call(argv, env=get_env())
     if rv:
         raise Fatal('fw: %r returned %d' % (argv, rv))
 
@@ -55,11 +46,7 @@ def nft(family, table, action, *args):
     else:
         raise Exception('Unsupported family "%s"' % family_to_string(family))
     debug1('%s\n' % ' '.join(argv))
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
-    rv = ssubprocess.call(argv, env=env)
+    rv = ssubprocess.call(argv, env=get_env())
     if rv:
         raise Fatal('fw: %r returned %d' % (argv, rv))
 

--- a/sshuttle/methods/__init__.py
+++ b/sshuttle/methods/__init__.py
@@ -1,9 +1,8 @@
-import os
 import importlib
 import socket
 import struct
 import errno
-from sshuttle.helpers import Fatal, debug3
+from sshuttle.helpers import Fatal, debug3, which
 
 
 def original_dst(sock):
@@ -87,27 +86,19 @@ class BaseMethod(object):
         return False
 
 
-def _program_exists(name):
-    paths = (os.getenv('PATH') or os.defpath).split(os.pathsep)
-    for p in paths:
-        fn = '%s/%s' % (p, name)
-        if os.path.exists(fn):
-            return not os.path.isdir(fn) and os.access(fn, os.X_OK)
-
-
 def get_method(method_name):
     module = importlib.import_module("sshuttle.methods.%s" % method_name)
     return module.Method(method_name)
 
 
 def get_auto_method():
-    if _program_exists('iptables'):
+    if which('iptables'):
         method_name = "nat"
-    elif _program_exists('nft'):
+    elif which('nft'):
         method_name = "nft"
-    elif _program_exists('pfctl'):
+    elif which('pfctl'):
         method_name = "pf"
-    elif _program_exists('ipfw'):
+    elif which('ipfw'):
         method_name = "ipfw"
     else:
         raise Fatal(

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -2,7 +2,7 @@ import os
 import subprocess as ssubprocess
 from sshuttle.methods import BaseMethod
 from sshuttle.helpers import log, debug1, debug3, \
-    Fatal, family_to_string
+    Fatal, family_to_string, get_env
 
 recvmsg = None
 try:
@@ -61,11 +61,7 @@ else:
 
 def ipfw_rule_exists(n):
     argv = ['ipfw', 'list']
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
-    p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=env)
+    p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=get_env())
 
     found = False
     for line in p.stdout:
@@ -85,11 +81,7 @@ _oldctls = {}
 
 def _fill_oldctls(prefix):
     argv = ['sysctl', prefix]
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
-    p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=env)
+    p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=get_env())
     for line in p.stdout:
         line = line.decode()
         assert(line[-1] == '\n')
@@ -105,7 +97,7 @@ def _fill_oldctls(prefix):
 def _sysctl_set(name, val):
     argv = ['sysctl', '-w', '%s=%s' % (name, val)]
     debug1('>> %s\n' % ' '.join(argv))
-    return ssubprocess.call(argv, stdout=open(os.devnull, 'w'))
+    return ssubprocess.call(argv, stdout=open(os.devnull, 'w'), env=get_env())
     # No env: No output. (Or error that won't be parsed.)
 
 
@@ -139,7 +131,7 @@ def sysctl_set(name, val, permanent=False):
 def ipfw(*args):
     argv = ['ipfw', '-q'] + list(args)
     debug1('>> %s\n' % ' '.join(argv))
-    rv = ssubprocess.call(argv)
+    rv = ssubprocess.call(argv, env=get_env())
     # No env: No output. (Or error that won't be parsed.)
     if rv:
         raise Fatal('%r returned %d' % (argv, rv))
@@ -148,7 +140,7 @@ def ipfw(*args):
 def ipfw_noexit(*args):
     argv = ['ipfw', '-q'] + list(args)
     debug1('>> %s\n' % ' '.join(argv))
-    ssubprocess.call(argv)
+    ssubprocess.call(argv, env=get_env())
     # No env: No output. (Or error that won't be parsed.)
 
 

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -7,24 +7,6 @@ import sys
 import os
 import platform
 
-if sys.version_info >= (3, 0):
-    from shutil import which
-else:
-    # python2 compat: shutil.which is not available so we provide our
-    # own which command
-    def which(file, mode=os.F_OK | os.X_OK, path=None):
-        if path is not None:
-            search_paths = [path]
-        elif "PATH" in os.environ:
-            search_paths = os.environ["PATH"].split(os.pathsep)
-        else:
-            search_paths = os.defpath.split(os.pathsep)
-
-        for p in search_paths:
-            filepath = os.path.join(p, file)
-            if os.path.exists(filepath) and os.access(filepath, mode):
-                return filepath
-        return None
 
 import sshuttle.ssnet as ssnet
 import sshuttle.helpers as helpers
@@ -32,7 +14,7 @@ import sshuttle.hostwatch as hostwatch
 import subprocess as ssubprocess
 from sshuttle.ssnet import Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import b, log, debug1, debug2, debug3, Fatal, \
-    resolvconf_random_nameserver
+    resolvconf_random_nameserver, which, get_env
 
 
 def _ipmatch(ipstr):
@@ -100,11 +82,7 @@ def _route_iproute(line):
 
 def _list_routes(argv, extract_route):
     # FIXME: IPv4 only
-    env = {
-        'PATH': os.environ['PATH'],
-        'LC_ALL': "C",
-    }
-    p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=env)
+    p = ssubprocess.Popen(argv, stdout=ssubprocess.PIPE, env=get_env())
     routes = []
     for line in p.stdout:
         if not line.strip():

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -97,7 +97,6 @@ def _list_routes(argv, extract_route):
     rv = p.wait()
     if rv != 0:
         log('WARNING: %r returned %d\n' % (argv, rv))
-        log('WARNING: That prevents --auto-nets from working.\n')
 
     return routes
 
@@ -108,7 +107,8 @@ def list_routes():
     elif which('netstat'):
         routes = _list_routes(['netstat', '-rn'], _route_netstat)
     else:
-        log('WARNING: Neither ip nor netstat were found on the server.\n')
+        log('WARNING: Neither "ip" nor "netstat" were found on the server. '
+            '--auto-nets feature will not work.\n')
         routes = []
 
     for (family, ip, width) in routes:

--- a/tests/client/test_methods_pf.py
+++ b/tests/client/test_methods_pf.py
@@ -4,7 +4,7 @@ from socket import AF_INET, AF_INET6
 import pytest
 from mock import Mock, patch, call, ANY
 from sshuttle.methods import get_method
-from sshuttle.helpers import Fatal
+from sshuttle.helpers import Fatal, get_env
 from sshuttle.methods.pf import FreeBsd, Darwin, OpenBsd
 
 
@@ -316,7 +316,8 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl,
              b'to <dns_servers> port 53 keep state\n'),
         call('-e'),
     ]
-    assert call(['kldload', 'pf']) in mock_subprocess_call.mock_calls
+    assert call(['kldload', 'pf'], env=get_env()) in \
+        mock_subprocess_call.mock_calls
     mock_pf_get_dev.reset_mock()
     mock_ioctl.reset_mock()
     mock_pfctl.reset_mock()


### PR DESCRIPTION
This patch attempts to fix (or aid in debugging) issue #350.

sshuttle didn't explicitly search /sbin and /usr/sbin and they may be
missing in the user's PATH. If PATH is missing, these folders wouldn't
be searched either. There was also a program_exists function which is
redundant to which(). This consolidates everything into the helpers.py
file.

This patch introduces get_path() to return PATH + some extra hardcoded
paths. A new get_env() function can be called to create a consistent
environment when calling external programs. The new which() wrapper
function also ensures we use the same set of paths.

If -vv is supplied, messages clearly indicate the programs we are
looking for, if they are found, and where we looked if we failed to
find them.

I haven't tested the changes to ipfw or pf.