### PR TITLE
Launch multiple sshuttle with different tproxy mark

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,6 +8,8 @@ on:
     branches: [ master, tproxy_mark_param ]
   pull_request:
     branches: [ master, tproxy_mark_param ]
+  workflow_dispatch:
+    branches: [ tproxy_mark_param ]
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -5,9 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, tproxy_mark_param ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, tproxy_mark_param ]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /.redo
 /.pytest_cache/
 /.python-version
+.vscode/

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -274,6 +274,10 @@ Options
     Set the file name for the sudoers.d file to be added. Default is
     "sshuttle_auto". Only works with --sudoers.
 
+.. option:: -t, --tmark
+
+    Transproxy optional traffic mark with provided MARK value.
+
 .. option:: --version
 
     Print program version.

--- a/docs/tproxy.rst
+++ b/docs/tproxy.rst
@@ -8,9 +8,11 @@ There are some things you need to consider for TPROXY to work:
   done once after booting up::
 
       ip route add local default dev lo table 100
-      ip rule add fwmark 1 lookup 100
+      ip rule add fwmark {TMARK} lookup 100
       ip -6 route add local default dev lo table 100
-      ip -6 rule add fwmark 1 lookup 100
+      ip -6 rule add fwmark {TMARK} lookup 100
+  
+  where {TMARK} is the identifier mark passed with -t or --tmark flag (default value is 1).
 
 - The ``--auto-nets`` feature does not detect IPv6 routes automatically. Add IPv6
   routes manually. e.g. by adding ``'::/0'`` to the end of the command line.

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -248,7 +248,7 @@ class FirewallClient:
 
     def setup(self, subnets_include, subnets_exclude, nslist,
               redirectport_v6, redirectport_v4, dnsport_v6, dnsport_v4, udp,
-              user):
+              user, tmark):
         self.subnets_include = subnets_include
         self.subnets_exclude = subnets_exclude
         self.nslist = nslist
@@ -258,6 +258,7 @@ class FirewallClient:
         self.dnsport_v4 = dnsport_v4
         self.udp = udp
         self.user = user
+        self.tmark = tmark
 
     def check(self):
         rv = self.p.poll()
@@ -576,7 +577,7 @@ def main(listenip_v6, listenip_v4,
          ssh_cmd, remotename, python, latency_control, dns, nslist,
          method_name, seed_hosts, auto_hosts, auto_nets,
          subnets_include, subnets_exclude, daemon, to_nameserver, pidfile,
-         user, sudo_pythonpath):
+         user, sudo_pythonpath, tmark):
 
     if not remotename:
         print("WARNING: You must specify -r/--remote to securely route "
@@ -902,7 +903,7 @@ def main(listenip_v6, listenip_v4,
     # start the firewall
     fw.setup(subnets_include, subnets_exclude, nslist,
              redirectport_v6, redirectport_v4, dnsport_v6, dnsport_v4,
-             required.udp, user)
+             required.udp, user, tmark)
 
     # start the client process
     try:

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -107,7 +107,8 @@ def main():
                                       opt.to_ns,
                                       opt.pidfile,
                                       opt.user,
-                                      opt.sudo_pythonpath)
+                                      opt.sudo_pythonpath,
+                                      opt.tmark)
 
             if return_code == 0:
                 log('Normal exit code, exiting...')

--- a/sshuttle/methods/tproxy.py
+++ b/sshuttle/methods/tproxy.py
@@ -152,7 +152,7 @@ class Method(BaseMethod):
 
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
                        user):
-        if self.firewall.tmark is None:
+        if self.firewall is None:
             tmark = '1'
         else:
             tmark = self.firewall.tmark

--- a/sshuttle/methods/tproxy.py
+++ b/sshuttle/methods/tproxy.py
@@ -153,10 +153,10 @@ class Method(BaseMethod):
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
                        user):
         self.setup_firewall_tproxy(port, dnsport, nslist, family, subnets, udp,
-                       user, self.firewall.tmark)
+                                   user, self.firewall.tmark)
 
-    def setup_firewall_tproxy(self, port, dnsport, nslist, family, subnets, udp,
-                       user, tmark):
+    def setup_firewall_tproxy(self, port, dnsport, nslist, family, subnets,
+                              udp, user, tmark):
         if family not in [socket.AF_INET, socket.AF_INET6]:
             raise Exception(
                 'Address family "%s" unsupported by tproxy method'

--- a/sshuttle/methods/tproxy.py
+++ b/sshuttle/methods/tproxy.py
@@ -152,8 +152,13 @@ class Method(BaseMethod):
 
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
                        user):
+        if self.firewall.tmark is None:
+            tmark = '1'
+        else:
+            tmark = self.firewall.tmark
+
         self.setup_firewall_tproxy(port, dnsport, nslist, family, subnets, udp,
-                                   user, self.firewall.tmark)
+                                   user, tmark)
 
     def setup_firewall_tproxy(self, port, dnsport, nslist, family, subnets,
                               udp, user, tmark):

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -409,3 +409,11 @@ parser.add_argument(
     do not set PYTHONPATH when invoking sudo
     """
 )
+parser.add_argument(
+    "-t", "--tmark",
+    metavar="[MARK]",
+    deafult="1",
+    help="""
+    transproxy optional traffic mark with provided MARK value
+    """
+)

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -412,7 +412,7 @@ parser.add_argument(
 parser.add_argument(
     "-t", "--tmark",
     metavar="[MARK]",
-    deafult="1",
+    default="1",
     help="""
     transproxy optional traffic mark with provided MARK value
     """


### PR DESCRIPTION
This PR resolves issue #374 

Add argument for tproxy mark and change code to receive this new parameter.
Coverage test only testing default case with mark='1' to allow passing tests. Needs further testing for new option, but didn't understand how firewall_setup method is being invoked (need help here).
Update documentation with new options.
Also update workflows and .gitignore for reference fork testing and development.
