### PR TITLE
Improve error messages related to sshuttle server.

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -537,6 +537,32 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
                     "to run programs specified with an absolute path. " \
                     "Try rerunning sshuttle with the --python parameter."
 
+        # When the redirected subnet includes the remote ssh host, the
+        # firewall rules can interrupt the ssh connection to the
+        # remote machine. This issue impacts some Linux machines. The
+        # user sees that the server dies with a broken pipe error and
+        # code 255.
+        #
+        # The solution to this problem is to exclude the remote
+        # server.
+        #
+        # There are many github issues from users encountering this
+        # problem. Most of the discussion on the topic is here:
+        # https://github.com/sshuttle/sshuttle/issues/191
+        elif rv == 255:
+            errmsg += "It might be possible to resolve this error by " \
+                "excluding the server that you are ssh'ing to. For example, " \
+                "if you are running 'sshuttle -v -r example.com 0/0' to " \
+                "redirect all traffic through example.com, then try " \
+                "'sshuttle -v -r example.com -x example.com 0/0' to " \
+                "exclude redirecting the connection to example.com itself " \
+                "(i.e., sshuttle's firewall rules may be breaking the " \
+                "ssh connection that it previously established). " \
+                "Alternatively, you may be able to use 'sshuttle -v -r " \
+                "example.com -x example.com:22 0/0' to redirect " \
+                "everything except ssh connections between your machine " \
+                "and example.com."
+
         raise Fatal(errmsg)
 
     if initstring != expected:

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -17,11 +17,11 @@ def main():
     if opt.sudoers or opt.sudoers_no_modify:
         if platform.platform().startswith('OpenBSD'):
             log('Automatic sudoers does not work on BSD')
-            exit(1)
+            return 1
 
         if not opt.sudoers_filename:
             log('--sudoers-file must be set or omited.')
-            exit(1)
+            return 1
 
         sudoers(
             user_name=opt.sudoers_user,

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -272,139 +272,146 @@ class UdpProxy(Handler):
 
 
 def main(latency_control, auto_hosts, to_nameserver, auto_nets):
-    debug1(' s: Starting server with Python version %s\n'
-           % platform.python_version())
+    try:
+        debug1(' s: Starting server with Python version %s\n'
+               % platform.python_version())
+        helpers.logprefix = ' s: '
+        debug1('latency control setting = %r\n' % latency_control)
 
-    helpers.logprefix = ' s: '
-    debug1('latency control setting = %r\n' % latency_control)
+        # synchronization header
+        sys.stdout.write('\0\0SSHUTTLE0001')
+        sys.stdout.flush()
 
-    # synchronization header
-    sys.stdout.write('\0\0SSHUTTLE0001')
-    sys.stdout.flush()
+        handlers = []
+        mux = Mux(sys.stdin, sys.stdout)
+        handlers.append(mux)
 
-    handlers = []
-    mux = Mux(sys.stdin, sys.stdout)
-    handlers.append(mux)
+        debug1('auto-nets:' + str(auto_nets) + '\n')
+        if auto_nets:
+            routes = list(list_routes())
+            debug1('available routes:\n')
+            for r in routes:
+                debug1('  %d/%s/%d\n' % r)
+        else:
+            routes = []
 
-    debug1('auto-nets:' + str(auto_nets) + '\n')
-    if auto_nets:
-        routes = list(list_routes())
-        debug1('available routes:\n')
+        routepkt = ''
         for r in routes:
-            debug1('  %d/%s/%d\n' % r)
-    else:
-        routes = []
+            routepkt += '%d,%s,%d\n' % r
+        mux.send(0, ssnet.CMD_ROUTES, b(routepkt))
 
-    routepkt = ''
-    for r in routes:
-        routepkt += '%d,%s,%d\n' % r
-    mux.send(0, ssnet.CMD_ROUTES, b(routepkt))
+        hw = Hostwatch()
+        hw.leftover = b('')
 
-    hw = Hostwatch()
-    hw.leftover = b('')
-
-    def hostwatch_ready(sock):
-        assert(hw.pid)
-        content = hw.sock.recv(4096)
-        if content:
-            lines = (hw.leftover + content).split(b('\n'))
-            if lines[-1]:
-                # no terminating newline: entry isn't complete yet!
-                hw.leftover = lines.pop()
-                lines.append(b(''))
+        def hostwatch_ready(sock):
+            assert(hw.pid)
+            content = hw.sock.recv(4096)
+            if content:
+                lines = (hw.leftover + content).split(b('\n'))
+                if lines[-1]:
+                    # no terminating newline: entry isn't complete yet!
+                    hw.leftover = lines.pop()
+                    lines.append(b(''))
+                else:
+                    hw.leftover = b('')
+                mux.send(0, ssnet.CMD_HOST_LIST, b('\n').join(lines))
             else:
-                hw.leftover = b('')
-            mux.send(0, ssnet.CMD_HOST_LIST, b('\n').join(lines))
-        else:
-            raise Fatal(' s: hostwatch process died')
+                raise Fatal(' s: hostwatch process died')
 
-    def got_host_req(data):
-        if not hw.pid:
-            (hw.pid, hw.sock) = start_hostwatch(
-                    data.decode("ASCII").strip().split(), auto_hosts)
-            handlers.append(Handler(socks=[hw.sock],
-                                    callback=hostwatch_ready))
-    mux.got_host_req = got_host_req
+        def got_host_req(data):
+            if not hw.pid:
+                (hw.pid, hw.sock) = start_hostwatch(
+                        data.decode("ASCII").strip().split(), auto_hosts)
+                handlers.append(Handler(socks=[hw.sock],
+                                        callback=hostwatch_ready))
+        mux.got_host_req = got_host_req
 
-    def new_channel(channel, data):
-        (family, dstip, dstport) = data.decode("ASCII").split(',', 2)
-        family = int(family)
-        # AF_INET is the same constant on Linux and BSD but AF_INET6
-        # is different. As the client and server can be running on
-        # different platforms we can not just set the socket family
-        # to what comes in the wire.
-        if family != socket.AF_INET:
-            family = socket.AF_INET6
-        dstport = int(dstport)
-        outwrap = ssnet.connect_dst(family, dstip, dstport)
-        handlers.append(Proxy(MuxWrapper(mux, channel), outwrap))
-    mux.new_channel = new_channel
-
-    dnshandlers = {}
-
-    def dns_req(channel, data):
-        debug2('Incoming DNS request channel=%d.\n' % channel)
-        h = DnsProxy(mux, channel, data, to_nameserver)
-        handlers.append(h)
-        dnshandlers[channel] = h
-    mux.got_dns_req = dns_req
-
-    udphandlers = {}
-
-    def udp_req(channel, cmd, data):
-        debug2('Incoming UDP request channel=%d, cmd=%d\n' % (channel, cmd))
-        if cmd == ssnet.CMD_UDP_DATA:
-            (dstip, dstport, data) = data.split(b(','), 2)
+        def new_channel(channel, data):
+            (family, dstip, dstport) = data.decode("ASCII").split(',', 2)
+            family = int(family)
+            # AF_INET is the same constant on Linux and BSD but AF_INET6
+            # is different. As the client and server can be running on
+            # different platforms we can not just set the socket family
+            # to what comes in the wire.
+            if family != socket.AF_INET:
+                family = socket.AF_INET6
             dstport = int(dstport)
-            debug2('is incoming UDP data. %r %d.\n' % (dstip, dstport))
-            h = udphandlers[channel]
-            h.send((dstip, dstport), data)
-        elif cmd == ssnet.CMD_UDP_CLOSE:
-            debug2('is incoming UDP close\n')
-            h = udphandlers[channel]
-            h.ok = False
-            del mux.channels[channel]
+            outwrap = ssnet.connect_dst(family, dstip, dstport)
+            handlers.append(Proxy(MuxWrapper(mux, channel), outwrap))
+        mux.new_channel = new_channel
 
-    def udp_open(channel, data):
-        debug2('Incoming UDP open.\n')
-        family = int(data)
-        mux.channels[channel] = lambda cmd, data: udp_req(channel, cmd, data)
-        if channel in udphandlers:
-            raise Fatal(' s: UDP connection channel %d already open' % channel)
-        else:
-            h = UdpProxy(mux, channel, family)
+        dnshandlers = {}
+
+        def dns_req(channel, data):
+            debug2('Incoming DNS request channel=%d.\n' % channel)
+            h = DnsProxy(mux, channel, data, to_nameserver)
             handlers.append(h)
-            udphandlers[channel] = h
-    mux.got_udp_open = udp_open
+            dnshandlers[channel] = h
+        mux.got_dns_req = dns_req
 
-    while mux.ok:
-        if hw.pid:
-            assert(hw.pid > 0)
-            (rpid, rv) = os.waitpid(hw.pid, os.WNOHANG)
-            if rpid:
-                raise Fatal(
-                    'hostwatch exited unexpectedly: code 0x%04x\n' % rv)
+        udphandlers = {}
 
-        ssnet.runonce(handlers, mux)
-        if latency_control:
-            mux.check_fullness()
+        def udp_req(channel, cmd, data):
+            debug2('Incoming UDP request channel=%d, cmd=%d\n' %
+                   (channel, cmd))
+            if cmd == ssnet.CMD_UDP_DATA:
+                (dstip, dstport, data) = data.split(b(','), 2)
+                dstport = int(dstport)
+                debug2('is incoming UDP data. %r %d.\n' % (dstip, dstport))
+                h = udphandlers[channel]
+                h.send((dstip, dstport), data)
+            elif cmd == ssnet.CMD_UDP_CLOSE:
+                debug2('is incoming UDP close\n')
+                h = udphandlers[channel]
+                h.ok = False
+                del mux.channels[channel]
 
-        if dnshandlers:
-            now = time.time()
-            remove = []
-            for channel, h in dnshandlers.items():
-                if h.timeout < now or not h.ok:
-                    debug3('expiring dnsreqs channel=%d\n' % channel)
-                    remove.append(channel)
-                    h.ok = False
-            for channel in remove:
-                del dnshandlers[channel]
-        if udphandlers:
-            remove = []
-            for channel, h in udphandlers.items():
-                if not h.ok:
-                    debug3('expiring UDP channel=%d\n' % channel)
-                    remove.append(channel)
-                    h.ok = False
-            for channel in remove:
-                del udphandlers[channel]
+        def udp_open(channel, data):
+            debug2('Incoming UDP open.\n')
+            family = int(data)
+            mux.channels[channel] = lambda cmd, data: udp_req(channel, cmd,
+                                                              data)
+            if channel in udphandlers:
+                raise Fatal(' s: UDP connection channel %d already open' %
+                            channel)
+            else:
+                h = UdpProxy(mux, channel, family)
+                handlers.append(h)
+                udphandlers[channel] = h
+        mux.got_udp_open = udp_open
+
+        while mux.ok:
+            if hw.pid:
+                assert(hw.pid > 0)
+                (rpid, rv) = os.waitpid(hw.pid, os.WNOHANG)
+                if rpid:
+                    raise Fatal(
+                        'hostwatch exited unexpectedly: code 0x%04x\n' % rv)
+
+            ssnet.runonce(handlers, mux)
+            if latency_control:
+                mux.check_fullness()
+
+            if dnshandlers:
+                now = time.time()
+                remove = []
+                for channel, h in dnshandlers.items():
+                    if h.timeout < now or not h.ok:
+                        debug3('expiring dnsreqs channel=%d\n' % channel)
+                        remove.append(channel)
+                        h.ok = False
+                for channel in remove:
+                    del dnshandlers[channel]
+            if udphandlers:
+                remove = []
+                for channel, h in udphandlers.items():
+                    if not h.ok:
+                        debug3('expiring UDP channel=%d\n' % channel)
+                        remove.append(channel)
+                        h.ok = False
+                for channel in remove:
+                    del udphandlers[channel]
+
+    except Fatal as e:
+        log('fatal: %s\n' % e)
+        sys.exit(99)


### PR DESCRIPTION
There are many GitHub issues related to the cryptic message:
fatal: expected server init string 'SSHUTTLE0001'; got b''

The code that prints that message is after another check that is
intended to verify that the server is still running. This code was
faulty since the server is still running when rv==None (but exited
when rv==0).

I corrected this problem and then investigated ways to clarify the
error message. I added additional exit codes for the server: 97 (exec
in the shell returned), 98 (the python exec() function called
returned). The end result is that the cryptic error message above will
now print a more appropriate error message that should aid in
debugging.

I also changed the server so that it catches Fatal() and exits with
exit code 99 (like the client does). Previously, it was just an
unhandled exception on the server.

I suspect some of the error messages were caused by restricted shells.
I also investigated and added comments about how sshuttle might behave
if it is being run on a server that has a restricted shell.

This commit also replaces a couple of exit() calls in cmdline.py with
'return' since exit() is intended for interactive use. This change
doesn't impact the server.