### PR TITLE
remove py35 from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/cache/
 envlist =
-    py35,
     py36,
     py37,
     py38,


### PR DESCRIPTION
Because the supported version is python3.6 and above.

https://github.com/sshuttle/sshuttle/blob/master/setup.py#L64