### PR TITLE
feat: remove mock from test dependencies.

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,6 +2,5 @@
 attrs==20.3.0
 pytest==6.2.1
 pytest-cov==2.10.1
-mock==4.0.3
 flake8==3.8.4
 pyflakes==2.2.0

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         'pytest',
         'pytest-cov',
         'pytest-runner',
-        'mock',
         'flake8',
     ],
     keywords="ssh vpn",

--- a/tests/client/test_firewall.py
+++ b/tests/client/test_firewall.py
@@ -1,7 +1,7 @@
 import io
 from socket import AF_INET, AF_INET6
 
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 import sshuttle.firewall
 
 

--- a/tests/client/test_helpers.py
+++ b/tests/client/test_helpers.py
@@ -3,7 +3,7 @@ import socket
 from socket import AF_INET, AF_INET6
 import errno
 
-from mock import patch, call
+from unittest.mock import patch, call
 import sshuttle.helpers
 
 

--- a/tests/client/test_methods_nat.py
+++ b/tests/client/test_methods_nat.py
@@ -3,7 +3,7 @@ from socket import AF_INET, AF_INET6
 import struct
 
 import pytest
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 from sshuttle.helpers import Fatal
 from sshuttle.methods import get_method
 

--- a/tests/client/test_methods_pf.py
+++ b/tests/client/test_methods_pf.py
@@ -2,7 +2,7 @@ import socket
 from socket import AF_INET, AF_INET6
 
 import pytest
-from mock import Mock, patch, call, ANY
+from unittest.mock import Mock, patch, call, ANY
 from sshuttle.methods import get_method
 from sshuttle.helpers import Fatal, get_env
 from sshuttle.methods.pf import FreeBsd, Darwin, OpenBsd

--- a/tests/client/test_methods_tproxy.py
+++ b/tests/client/test_methods_tproxy.py
@@ -1,7 +1,7 @@
 import socket
 from socket import AF_INET, AF_INET6
 
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 
 from sshuttle.methods import get_method
 

--- a/tests/client/test_sdnotify.py
+++ b/tests/client/test_sdnotify.py
@@ -1,6 +1,6 @@
 import socket
 
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 
 import sshuttle.sdnotify
 

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1,7 +1,7 @@
 import io
 import socket
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 import sshuttle.server
 


### PR DESCRIPTION
Because mock can be replace by unittest.mock

https://docs.python.org/3/library/unittest.mock.html