### PR TITLE
chore: remove attrs from requirements-test.txt

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
-attrs==20.3.0
 pytest==6.2.1
 pytest-cov==2.10.1
 flake8==3.8.4


### PR DESCRIPTION
It used to be necessary to fix the version of attrs when using pytest. 
This problem has been fixed now, so I removed it.

https://stackoverflow.com/a/58198754