### PR TITLE
--latency-buffer-size now impacts server's buffer.

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -40,5 +40,6 @@ sshuttle.helpers.verbose = verbosity
 
 import sshuttle.cmdline_options as options  # noqa: E402
 from sshuttle.server import main  # noqa: E402
-main(options.latency_control, options.auto_hosts, options.to_nameserver,
+main(options.latency_control, options.latency_buffer_size,
+     options.auto_hosts, options.to_nameserver,
      options.auto_nets)

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -440,7 +440,7 @@ def ondns(listener, method, mux, handlers):
 
 
 def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
-          python, latency_control,
+          python, latency_control, latency_buffer_size,
           dns_listener, seed_hosts, auto_hosts, auto_nets, daemon,
           to_nameserver):
 
@@ -458,6 +458,7 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
             ssh_cmd, remotename, python,
             stderr=ssyslog._p and ssyslog._p.stdin,
             options=dict(latency_control=latency_control,
+                         latency_buffer_size=latency_buffer_size,
                          auto_hosts=auto_hosts,
                          to_nameserver=to_nameserver,
                          auto_nets=auto_nets))
@@ -650,7 +651,8 @@ def _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
 
 
 def main(listenip_v6, listenip_v4,
-         ssh_cmd, remotename, python, latency_control, dns, nslist,
+         ssh_cmd, remotename, python, latency_control,
+         latency_buffer_size, dns, nslist,
          method_name, seed_hosts, auto_hosts, auto_nets,
          subnets_include, subnets_exclude, daemon, to_nameserver, pidfile,
          user, sudo_pythonpath, tmark):
@@ -984,8 +986,9 @@ def main(listenip_v6, listenip_v4,
     # start the client process
     try:
         return _main(tcp_listener, udp_listener, fw, ssh_cmd, remotename,
-                     python, latency_control, dns_listener,
-                     seed_hosts, auto_hosts, auto_nets, daemon, to_nameserver)
+                     python, latency_control, latency_buffer_size,
+                     dns_listener, seed_hosts, auto_hosts, auto_nets,
+                     daemon, to_nameserver)
     finally:
         try:
             if daemon:

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -95,6 +95,7 @@ def main():
                                       remotename,
                                       opt.python,
                                       opt.latency_control,
+                                      opt.latency_buffer_size,
                                       opt.dns,
                                       nslist,
                                       opt.method,

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -271,13 +271,17 @@ class UdpProxy(Handler):
         self.mux.send(self.chan, ssnet.CMD_UDP_DATA, hdr + data)
 
 
-def main(latency_control, auto_hosts, to_nameserver, auto_nets):
+def main(latency_control, latency_buffer_size, auto_hosts, to_nameserver,
+         auto_nets):
     try:
         helpers.logprefix = ' s: '
         debug1('Starting server with Python version %s'
                % platform.python_version())
 
         debug1('latency control setting = %r' % latency_control)
+        if latency_buffer_size:
+            import sshuttle.ssnet as ssnet
+            ssnet.LATENCY_BUFFER_SIZE = latency_buffer_size
 
         # synchronization header
         sys.stdout.write('\0\0SSHUTTLE0001')

--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -461,7 +461,10 @@ class Mux(Handler):
             flags |= os.O_NONBLOCK
             flags = fcntl.fcntl(self.rfile.fileno(), fcntl.F_SETFL, flags)
         try:
-            read = _nb_clean(os.read, self.rfile.fileno(), LATENCY_BUFFER_SIZE)
+            # If LATENCY_BUFFER_SIZE is inappropriately large, we will
+            # get a MemoryError here. Read no more than 1MiB.
+            read = _nb_clean(os.read, self.rfile.fileno(),
+                             min(1048576, LATENCY_BUFFER_SIZE))
         except OSError:
             _, e = sys.exc_info()[:2]
             raise Fatal('other end: %r' % e)


### PR DESCRIPTION
sshuttle has a --latency-buffer-size parameter, but it only changes
the buffer size on the client and not the server. Therefore,
increasing or decreasing the number doesn't make any change in
download performance (like the documentation indicates that it should).

You can test this change by setting up a sshuttle connection and
downloading a large file through sshuttle. With this patch, you should
find that increasing --latency-buffer-size increases the download
speed. Without the patch, the parameter should have little impact on
performance.