### PR TITLE
Allow comments in configuration file

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -305,6 +305,17 @@ Arguments read from a file must be one per line, as shown below::
     --option2
     value2
 
+Comments in config file
+.......................
+
+It's possible to add comments in the configuration file. This allows annotating the
+various subnets with human-readable descriptions, like::
+
+    # company-internal API
+    8.8.8.8/32
+    # home IoT
+    192.168.63.0/24
+
 
 Examples
 --------

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -68,8 +68,8 @@ Options
     You can use any name resolving to an IP address of the machine running
     :program:`sshuttle`, e.g. ``--listen localhost``.
 
-    For the nft, tproxy and pf methods this can be an IPv6 address. Use 
-    this option with comma separated values if required, to provide both 
+    For the nft, tproxy and pf methods this can be an IPv6 address. Use
+    this option with comma separated values if required, to provide both
     IPv4 and IPv6 addresses, e.g. ``--listen 127.0.0.1:0,[::1]:0``.
 
 .. option:: -H, --auto-hosts
@@ -104,7 +104,7 @@ Options
 
     Capture local DNS requests and forward to the remote DNS
     server. All queries to any of the local system's DNS
-    servers (/etc/resolv.conf and, if it exists, 
+    servers (/etc/resolv.conf and, if it exists,
     /run/systemd/resolve/resolv.conf) will be intercepted and
     resolved on the remote side of the tunnel instead, there
     using the DNS specified via the :option:`--to-ns` option,

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -152,6 +152,10 @@ class Concat(Action):
 # beginning/end of the lines.
 class MyArgumentParser(ArgumentParser):
     def convert_arg_line_to_args(self, arg_line):
+        # Ignore comments
+        if arg_line.startswith("#"):
+            return []
+
         # strip whitespace at beginning and end of line
         arg_line = arg_line.strip()
 

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -100,3 +100,8 @@ def test_parse_subnetport_ip6_with_mask_and_port():
             == [(socket.AF_INET6, ip, 128, 80, 80)]
         assert sshuttle.options.parse_subnetport('[' + ip_repr + '/16]:80-90')\
             == [(socket.AF_INET6, ip, 16, 80, 90)]
+
+
+def test_convert_arg_line_to_args_skips_comments():
+    parser = sshuttle.options.MyArgumentParser()
+    assert parser.convert_arg_line_to_args("# whatever something") == []


### PR DESCRIPTION
As discussed in #562, i'd like to submit a patch which allows comments in the configuration file. 

The test supplied with this patch does not seem to convincing to me, but once you accept that argparse completely ignores empty lists returned from `convert_arg_line_to_args` then it makes sense.

Of course, i'm open to improvements.

