### PR TITLE
Allow override of the default tunnel TTL.

### DIFF
--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -37,6 +37,13 @@ def main():
     if opt.latency_buffer_size:
         import sshuttle.ssnet as ssnet
         ssnet.LATENCY_BUFFER_SIZE = opt.latency_buffer_size
+    if opt.no_ttl_hack:
+        import sshuttle.ssnet as ssnet
+        ssnet.NO_TTL_HACK = True
+    if opt.tunnel_ttl:
+        import sshuttle.ssnet as ssnet
+        ssnet.TUNNEL_TTL = opt.tunnel_ttl
+
     helpers.verbose = opt.verbose
 
     try:

--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -58,7 +58,7 @@ def ipt_ttl(family, *args):
     global _no_ttl_module
     if not _no_ttl_module:
         # we avoid infinite loops by generating server-side connections
-        # with ttl 63.  This makes the client side not recapture those
+        # with ttl set in ssnet.TUNNEL_TTL.  This makes the client side not recapture those
         # connections, in case client == server.
         try:
             argsplus = list(args)

--- a/sshuttle/methods/nat.py
+++ b/sshuttle/methods/nat.py
@@ -52,8 +52,8 @@ class Method(BaseMethod):
 
         # This TTL hack allows the client and server to run on the
         # same host. The connections the sshuttle server makes will
-        # have TTL set to 63.
-        _ipt_ttl('-A', chain, '-j', 'RETURN',  '-m', 'ttl', '--ttl', '63')
+        # have TTL set to ssnet.TUNNEL_TTL.
+        _ipt_ttl('-A', chain, '-j', 'RETURN',  '-m', 'ttl', '--ttl', ssnet.TUNNEL_TTL)
 
         # Redirect DNS traffic as requested. This includes routing traffic
         # to localhost DNS servers through sshuttle.

--- a/sshuttle/methods/nft.py
+++ b/sshuttle/methods/nft.py
@@ -47,11 +47,11 @@ class Method(BaseMethod):
 
         # This TTL hack allows the client and server to run on the
         # same host. The connections the sshuttle server makes will
-        # have TTL set to 63.
+        # have TTL set to ssnet.TUNNEL_TTL.
         if family == socket.AF_INET:
-            _nft('add rule', chain, 'ip ttl == 63 return')
+            _nft('add rule', chain, 'ip ttl == %s return' % ssnet.TUNNEL_TTL)
         elif family == socket.AF_INET6:
-            _nft('add rule', chain, 'ip6 hoplimit == 63 return')
+            _nft('add rule', chain, 'ip6 hoplimit == %s return', ssnet.TUNNEL_TTL)
 
         # Strings to use below to simplify our code
         if family == socket.AF_INET:

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -323,6 +323,23 @@ parser.add_argument(
     """
 )
 parser.add_argument(
+    "--no-ttl-hack",
+    action="store_true",
+    dest="no_ttl_hack",
+    help="""
+    disable using the tunnel packet ttl for loop detection.
+    """
+)
+parser.add_argument(
+    "--tunnel-ttl",
+    type=int,
+    default=63,
+    dest="tunnel_ttl",
+    help="""
+    IP TTL used to detect loops when client and are server are on the same host.
+    """
+)
+parser.add_argument(
     "--wrap",
     metavar="NUM",
     type=int,

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -16,7 +16,6 @@ from sshuttle.ssnet import Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import b, log, debug1, debug2, debug3, Fatal, \
     resolvconf_random_nameserver, which, get_env
 
-
 def _ipmatch(ipstr):
     # FIXME: IPv4 only
     if ipstr == 'default':
@@ -191,7 +190,7 @@ class DnsProxy(Handler):
 
         family, sockaddr = self._addrinfo(peer, port)
         sock = socket.socket(family, socket.SOCK_DGRAM)
-        sock.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)
+        sock.setsockopt(socket.SOL_IP, socket.IP_TTL, ssnet.TUNNEL_TTL)
         sock.connect(sockaddr)
 
         self.peers[sock] = peer
@@ -248,7 +247,7 @@ class UdpProxy(Handler):
         self.chan = chan
         self.sock = sock
         if family == socket.AF_INET:
-            self.sock.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)
+            self.sock.setsockopt(socket.SOL_IP, socket.IP_TTL, ssnet.TUNNEL_TTL)
 
     def send(self, dstip, data):
         debug2('UDP: sending to %r port %d' % dstip)

--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -11,6 +11,12 @@ from sshuttle.helpers import b, log, debug1, debug2, debug3, Fatal
 MAX_CHANNEL = 65535
 LATENCY_BUFFER_SIZE = 32768
 
+# packet TTL to use for loop detection.
+TUNNEL_TTL = 63
+
+# Disable TTL hack entirely.
+NO_TTL_HACK = False
+
 SHUT_RD = 0
 SHUT_WR = 1
 SHUT_RDWR = 2
@@ -586,7 +592,7 @@ class MuxWrapper(SockWrapper):
 def connect_dst(family, ip, port):
     debug2('Connecting to %s:%d' % (ip, port))
     outsock = socket.socket(family)
-    outsock.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)
+    outsock.setsockopt(socket.SOL_IP, socket.IP_TTL, TUNNEL_TTL)
     return SockWrapper(outsock, outsock,
                        connect_to=(ip, port),
                        peername='%s:%d' % (ip, port))


### PR DESCRIPTION
The default ttl of 63 that's used for loop detection
causes problems for packets that originate from virtual
machines/containers running on the client.

Add an option to override the TTL or disable it entirely.

WIP: tests do not pass yet.