### PR TITLE
Allow using doas on linux systems

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -199,7 +199,7 @@ class MultiListener:
 
 class FirewallClient:
 
-    def __init__(self, method_name, sudo_pythonpath, ttl):
+    def __init__(self, method_name, sudo_pythonpath, ttl, force_doas):
         self.auto_nets = []
         python_path = os.path.dirname(os.path.dirname(__file__))
         argvbase = ([sys.executable, sys.argv[0]] +
@@ -211,7 +211,7 @@ class FirewallClient:
             argvbase += ['--syslog']
 
         # Determine how to prefix the command in order to elevate privileges.
-        if platform.platform().startswith('OpenBSD'):
+        if force_doas or platform.platform().startswith('OpenBSD'):
             elev_prefix = ['doas']  # OpenBSD uses built in `doas`
         else:
             elev_prefix = ['sudo', '-p', '[local sudo] Password: ']
@@ -670,7 +670,7 @@ def main(listenip_v6, listenip_v4,
          latency_buffer_size, dns, nslist,
          method_name, seed_hosts, auto_hosts, auto_nets,
          subnets_include, subnets_exclude, daemon, to_nameserver, pidfile,
-         user, sudo_pythonpath, tmark, ttl):
+         user, sudo_pythonpath, tmark, ttl, force_doas):
 
     if not remotename:
         print("WARNING: You must specify -r/--remote to securely route "
@@ -686,7 +686,7 @@ def main(listenip_v6, listenip_v4,
     debug1('Starting sshuttle proxy (version %s).' % __version__)
     helpers.logprefix = 'c : '
 
-    fw = FirewallClient(method_name, sudo_pythonpath, ttl)
+    fw = FirewallClient(method_name, sudo_pythonpath, ttl, force_doas)
 
     # If --dns is used, store the IP addresses that the client
     # normally uses for DNS lookups in nslist. The firewall needs to

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -15,8 +15,8 @@ def main():
     opt = parser.parse_args()
 
     if opt.sudoers or opt.sudoers_no_modify:
-        if platform.platform().startswith('OpenBSD'):
-            log('Automatic sudoers does not work on BSD')
+        if opt.doas or platform.platform().startswith('OpenBSD'):
+            log('Automatic sudoers does not work with doas')
             return 1
 
         if not opt.sudoers_filename:
@@ -110,7 +110,8 @@ def main():
                                       opt.user,
                                       opt.sudo_pythonpath,
                                       opt.tmark,
-                                      opt.ttl)
+                                      opt.ttl,
+                                      opt.doas)
 
             if return_code == 0:
                 log('Normal exit code, exiting...')

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -348,6 +348,7 @@ parser.add_argument(
     run in the background as a daemon
     """
 )
+
 parser.add_argument(
     "-s", "--subnets",
     metavar="PATH",
@@ -447,5 +448,12 @@ parser.add_argument(
     default="1",
     help="""
     transproxy optional traffic mark with provided MARK value
+    """
+)
+parser.add_argument(
+    "-d", "--doas",
+    action="store_true",
+    help="""
+    force using doas instead of sudo on linux systems
     """
 )


### PR DESCRIPTION
Some linux distributions allow switching `sudo` with `doas`. This PR adds a flag `-d --doas` which allows users to use `doas` for privilege elevation.