### PR TITLE
Fix firewall setup/teardown failure on xtable lock

### DIFF
--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -17,7 +17,7 @@ def ipt_chain_exists(family, table, name):
         cmd = 'iptables'
     else:
         raise Exception('Unsupported family "%s"' % family_to_string(family))
-    argv = [cmd, '-t', table, '-nL']
+    argv = [cmd, '-w', '-t', table, '-nL']
     try:
         output = ssubprocess.check_output(argv, env=get_env())
         for line in output.decode('ASCII').split('\n'):
@@ -29,9 +29,9 @@ def ipt_chain_exists(family, table, name):
 
 def ipt(family, table, *args):
     if family == socket.AF_INET6:
-        argv = ['ip6tables', '-t', table] + list(args)
+        argv = ['ip6tables', '-w', '-t', table] + list(args)
     elif family == socket.AF_INET:
-        argv = ['iptables', '-t', table] + list(args)
+        argv = ['iptables', '-w', '-t', table] + list(args)
     else:
         raise Exception('Unsupported family "%s"' % family_to_string(family))
     debug1('%s' % ' '.join(argv))


### PR DESCRIPTION
I have a use case where I need two sshuttle instances at the same time:
```
# Create tunnel A
sshuttle -r $SERVER_A $NETMASK_A --daemon --pidfile=$PIDFILE_A
# Create tunnel B
sshuttle -r $SERVER_B $NETMASK_B --daemon --pidfile=$PIDFILE_B

# Do stuff ...

# Shutdown tunnel B
kill $(cat ${PIDFILE_B})
# Shutdown tunnel A
kill $(cat ${PIDFILE_A})
```
In the second `sshuttle` call, (and the second `kill`), `iptables` fails, complaining about "Another app is currently holding the xtables lock" (see below).
This patch adds the `-w` option to all `iptables` calls, making sure they wait for the other instance releasing the lock.

Not sure if it's necessary to add a timeout value (right now it can potentially wait for the lock indefinitely), and if the other firewall methods (other than `iptables`) need to be patched as well.

```
sshuttle[15918]: c : exiting on signal 15
sshuttle[15922]: fw: undoing changes.
sshuttle[16023]: c : exiting on signal 15
sshuttle[15922]: Another app is currently holding the xtables lock. Perhaps you want to use the -w option?
sshuttle[15922]: fw: Error trying to undo IPv4 firewall.
sshuttle[15922]: fw: Traceback (most recent call last):
sshuttle[15922]:       File "/home/patrick/src/tmp/sshuttle/sshuttle/linux.py", line 22, in ipt_chain_exists
sshuttle[15922]:         output = ssubprocess.check_output(argv, env=get_env())
sshuttle[15922]:       File "/usr/lib/python3.8/subprocess.py", line 411, in check_output
sshuttle[15922]:         return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
sshuttle[15922]:       File "/usr/lib/python3.8/subprocess.py", line 512, in run
sshuttle[15922]:         raise CalledProcessError(retcode, process.args,
sshuttle[15922]:     subprocess.CalledProcessError: Command '['iptables', '-t', 'nat', '-nL']' returned non-zero exit status 4.
sshuttle[15922]:
sshuttle[15922]:     During handling of the above exception, another exception occurred:
sshuttle[15922]:
sshuttle[15922]:     Traceback (most recent call last):
sshuttle[15922]:       File "/home/patrick/src/tmp/sshuttle/sshuttle/firewall.py", line 274, in main
sshuttle[15922]:         method.restore_firewall(port_v4, socket.AF_INET, udp, user)
sshuttle[15922]:       File "/home/patrick/src/tmp/sshuttle/sshuttle/methods/nat.py", line 111, in restore_firewall
sshuttle[15922]:         if ipt_chain_exists(family, table, chain):
sshuttle[15922]:       File "/home/patrick/src/tmp/sshuttle/sshuttle/linux.py", line 27, in ipt_chain_exists
sshuttle[15922]:         raise Fatal('%r returned %d' % (argv, e.returncode))
sshuttle[15922]:     sshuttle.helpers.Fatal: ['iptables', '-t', 'nat', '-nL'] returned 4
sshuttle[15918]: c : SW#8:192.168.111.48:54944: deleting (3 remain)
sshuttle[15918]: c : SW'unknown':Mux#1: deleting (2 remain)
sshuttle[15918]: c : SW'unknown':Mux#2: deleting (1 remain)
sshuttle[15918]: c : SW#10:192.168.111.48:54946: deleting (0 remain)
sshuttle[16023]: client_loop: send disconnect: Broken pipe
```