### PR TITLE
Fix DnsProxy

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -206,7 +206,7 @@ class FirewallClient:
                     ['-v'] * (helpers.verbose or 0) +
                     ['--method', method_name] +
                     ['--firewall'] +
-                    ['--ttl', ttl])
+                    ['--ttl', str(ttl)])
         if ssyslog._p:
             argvbase += ['--syslog']
 

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -389,7 +389,8 @@ parser.add_argument(
 )
 parser.add_argument(
     "--ttl",
-    default="63",
+    type=int,
+    default=63,
     help="""
     Override the TTL for the connections made by the sshuttle server.
     Default is 63.


### PR DESCRIPTION
When using `sshuttle` with DNS forwarding, the server part calls `setsockopt` with a string value for TTL and fails (see below). In my case the `DnsProxy` was initialized with a string value "63" as `ttl` argument.
This patch fixes it by casting ttl to `int` type.

```
sshuttle[4549]: c : DNS request from ('192.168.111.9', 33380): 35 bytes
sshuttle[4549]: c : DNS request from ('192.168.111.9', 58082): 35 bytes
sshuttle[4549]:  s: setsockopt: 63
sshuttle[4549]: Traceback (most recent call last):
sshuttle[4549]:   File "<string>", line 1, in <module>
sshuttle[4549]:   File "assembler.py", line 43, in <module>
sshuttle[4549]:   File "sshuttle.server", line 398, in main
sshuttle[4549]:   File "sshuttle.ssnet", line 616, in runonce
sshuttle[4549]:   File "sshuttle.ssnet", line 504, in callback
sshuttle[4549]:   File "sshuttle.ssnet", line 492, in handle
sshuttle[4549]:   File "sshuttle.ssnet", line 411, in got_packet
sshuttle[4549]:   File "sshuttle.server", line 354, in dns_req
sshuttle[4549]:   File "sshuttle.server", line 172, in __init__
sshuttle[4549]:   File "sshuttle.server", line 196, in try_send
sshuttle[4549]: TypeError: a bytes-like object is required, not 'str'
```