### PR TITLE
Warn about adding sshuttle to sudoers.

### DIFF
--- a/sshuttle/sudoers.py
+++ b/sshuttle/sudoers.py
@@ -19,9 +19,14 @@ Cmnd_Alias %(ca)s = /usr/bin/env PYTHONPATH=%(dist_packages)s %(py)s %(path)s *
 %(user_name)s ALL=NOPASSWD: %(ca)s
 '''
 
+warning_msg = "# WARNING: When you allow a user to run sshuttle as root,\n" \
+              "# they can then use sshuttle's --ssh-cmd option to run any\n" \
+              "# command as root.\n"
+
 
 def build_config(user_name):
-    content = template % {
+    content = warning_msg
+    content += template % {
         'ca': command_alias,
         'dist_packages': path_to_dist_packages,
         'py': sys.executable,
@@ -42,6 +47,7 @@ def save_config(content, file_name):
     process.stdin.write(content.encode())
 
     streamdata = process.communicate()[0]
+    sys.stdout.write(streamdata.decode("ASCII"))
     returncode = process.returncode
 
     if returncode:
@@ -61,4 +67,5 @@ def sudoers(user_name=None, no_modify=None, file_name=None):
         sys.stdout.write(content)
         exit(0)
     else:
+        sys.stdout.write(warning_msg)
         save_config(content, file_name)


### PR DESCRIPTION
Issue #631 suggests that we should warn about users who add sshuttle
to sudoers because it isn't obvious that when a user can run sshuttle
as root, they can run any command as root using sshuttle's -e or
--ssh-cmd parameters.

This patch adds a comment that warns about this problem to the sudoers
file. It also prints the warning to the console if the user uses an
option that writes the data directly to the file. This patch also
causes the output of the sudoers-add command to be printed to the
console so that the user can see the name of the file that was
created.

There is room for improvement: Warnings could be added to the
documentation and/or these parameters could be removed entirely.