### PR TITLE
Only attempt to set TTL for IPv4, FreeBSD at least complains for v6.

### DIFF
--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -586,7 +586,8 @@ class MuxWrapper(SockWrapper):
 def connect_dst(family, ip, port):
     debug2('Connecting to %s:%d' % (ip, port))
     outsock = socket.socket(family)
-    outsock.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)
+    if family == socket.AF_INET:
+        outsock.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)
     return SockWrapper(outsock, outsock,
                        connect_to=(ip, port),
                        peername='%s:%d' % (ip, port))


### PR DESCRIPTION
Without this any TCPv6 connection going to my FreeBSD machine causes sshuttle to crash:
```
[osx 11:12] ~ >sshuttle -r me@freebsd.server 10.0.2.0/24 1234:5678:9abc:1::/24 
c : Connected to server.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "assembler.py", line 45, in <module>
  File "sshuttle.server", line 397, in main
  File "sshuttle.ssnet", line 616, in runonce
  File "sshuttle.ssnet", line 504, in callback
  File "sshuttle.ssnet", line 492, in handle
  File "sshuttle.ssnet", line 407, in got_packet
  File "sshuttle.server", line 345, in new_channel
  File "sshuttle.ssnet", line 589, in connect_dst
OSError: [Errno 22] Invalid argument
c : fatal: ssh connection to server (pid 82423) exited with returncode 1
Connection failed
```

Where line 589 is "outsock.setsockopt(socket.SOL_IP, socket.IP_TTL, 63)".
