### PR TITLE
Print server's python version earlier

### DIFF
--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -1,8 +1,12 @@
 import sys
 import zlib
 import types
+import platform
 
 verbosity = verbosity  # noqa: F821 must be a previously defined global
+if verbosity > 0:
+    sys.stderr.write(' s: Running server on remote host with %s (version %s)\n'
+                     % (sys.executable, platform.python_version()))
 z = zlib.decompressobj()
 while 1:
     name = sys.stdin.readline().strip()

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -5,7 +5,6 @@ import traceback
 import time
 import sys
 import os
-import platform
 
 
 import sshuttle.ssnet as ssnet
@@ -272,8 +271,6 @@ def main(latency_control, latency_buffer_size, auto_hosts, to_nameserver,
          auto_nets):
     try:
         helpers.logprefix = ' s: '
-        debug1('Starting server with Python version %s'
-               % platform.python_version())
 
         debug1('latency control setting = %r' % latency_control)
         if latency_buffer_size:


### PR DESCRIPTION
Previously, we printed the server's python version in server.py.
Moving it to assembler.py means that it can be printed earlier so that
it can be seen before a potential error that could occur during
assembly. Additionally, the path to the python executable used by the
server was added to the output as well.

An example of where this would be useful: #666