### PR TITLE
Improve error message when sudo's use_pty option is enabled.

### DIFF
--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -70,7 +70,14 @@ def setup_daemon():
 
     # ctrl-c shouldn't be passed along to me.  When the main sshuttle dies,
     # I'll die automatically.
-    os.setsid()
+    try:
+        os.setsid()
+    except OSError:
+        raise Fatal("setsid() failed. This may occur if you are using sudo's "
+                    "use_pty option. sshuttle does not currently work with "
+                    "this option. An imperfect workaround: Run the sshuttle "
+                    "command with sudo instead of running it as a regular "
+                    "user and entering the sudo password when prompted.")
 
     # because of limitations of the 'su' command, the *real* stdin/stdout
     # are both attached to stdout initially.  Clone stdout into stdin so we


### PR DESCRIPTION
If sudo's use_pty is enabled, the setsid() call in firewall.py will
fail (see #664). When I ignore the error, sshuttle does not behave
properly. This patch explains to the user what is happening and
suggests a workaround.

It might be possible to make sshuttle work with use_pty in the future.