### PR TITLE
Make ipfw method work

### DIFF
--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -205,7 +205,7 @@ class Method(BaseMethod):
 
         if subnets:
             # create new subnet entries
-            for _, swidth, sexclude, snet in sorted(subnets,
+            for _, swidth, sexclude, snet, fport, lport in sorted(subnets,
                                                     key=lambda s: s[1],
                                                     reverse=True):
                 if sexclude:

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -178,8 +178,7 @@ class Method(BaseMethod):
         if subnets or dnsport:
             sysctl_set('net.inet.ip.fw.enable', 1)
 
-        ipfw('add', '1', 'check-state', 'ip',
-             'from', 'any', 'to', 'any')
+        ipfw('add', '1', 'check-state')
 
         ipfw('add', '1', 'skipto', '2',
              'tcp',

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -186,7 +186,7 @@ class Method(BaseMethod):
         ipfw('add', '1', 'fwd', '127.0.0.1,%d' % port,
              'tcp',
              'from', 'any', 'to', 'table(126)',
-             'not', 'ipttl', ttl, 'keep-state', 'setup')
+             'not', 'ipttl', '%d' % ttl, 'keep-state', 'setup')
 
         ipfw_noexit('table', '124', 'flush')
         dnscount = 0
@@ -197,11 +197,11 @@ class Method(BaseMethod):
             ipfw('add', '1', 'fwd', '127.0.0.1,%d' % dnsport,
                  'udp',
                  'from', 'any', 'to', 'table(124)',
-                 'not', 'ipttl', ttl)
+                 'not', 'ipttl', '%d' % ttl)
         ipfw('add', '1', 'allow',
              'udp',
              'from', 'any', 'to', 'any',
-             'ipttl', ttl)
+             'ipttl', '%d' % ttl)
 
         if subnets:
             # create new subnet entries

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -216,7 +216,7 @@ class Method(BaseMethod):
     def restore_firewall(self, port, family, udp, user):
         if family not in [socket.AF_INET]:
             raise Exception(
-                'Address family "%s" unsupported by tproxy method'
+                'Address family "%s" unsupported by ipfw method'
                 % family_to_string(family))
 
         ipfw_noexit('delete', '1')

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -33,7 +33,7 @@ def ipfw_rule_exists(n):
     found = False
     for line in p.stdout:
         if line.startswith(b'%05d ' % n):
-            if not 'check-state :sshuttle' in line:
+            if 'check-state :sshuttle' not in line:
                 log('non-sshuttle ipfw rule: %r' % line.strip())
                 raise Fatal('non-sshuttle ipfw rule #%d already exists!' % n)
             found = True
@@ -201,8 +201,8 @@ class Method(BaseMethod):
         if subnets:
             # create new subnet entries
             for _, swidth, sexclude, snet, fport, lport in sorted(subnets,
-                                                    key=lambda s: s[1],
-                                                    reverse=True):
+                                                                  key=lambda s: s[1],
+                                                                  reverse=True):
                 if sexclude:
                     ipfw('table', '125', 'add', '%s/%s' % (snet, swidth))
                 else:

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -200,9 +200,8 @@ class Method(BaseMethod):
 
         if subnets:
             # create new subnet entries
-            for _, swidth, sexclude, snet, fport, lport in sorted(subnets,
-                                                                  key=lambda s: s[1],
-                                                                  reverse=True):
+            for _, swidth, sexclude, snet, fport, lport \
+                    in sorted(subnets, key=lambda s: s[1], reverse=True):
                 if sexclude:
                     ipfw('table', '125', 'add', '%s/%s' % (snet, swidth))
                 else:

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -210,8 +210,8 @@ class Method(BaseMethod):
                                                     reverse=True):
                 if sexclude:
                     ipfw('table', '125', 'add', '%s/%s' % (snet, swidth))
-            else:
-                ipfw('table', '126', 'add', '%s/%s' % (snet, swidth))
+                else:
+                    ipfw('table', '126', 'add', '%s/%s' % (snet, swidth))
 
     def restore_firewall(self, port, family, udp, user):
         if family not in [socket.AF_INET]:


### PR DESCRIPTION
The ipfw method is broken. The patch makes it work on FreeBSD 13 and I guess most if not all other versions. There are 5 pieces in the patch:

1 - Change the check-state to only "ipfw -q add 1 check-state". The extra "ip from any to any" causes an error. I'm not sure if it was ever allowed.

2 - Add fport and lport (unused) to the for that parse subnets. Otherwise python is unhappy with "ValueError: too many values to unpack (expected 4)"

3 - Indent the else to the same depth as the if.

4 - Changetext from tproxy to ipfw.

5 - Remove the ttl 63 hack that was already removed from other methods.

With this it worked for what I needed.