### PR TITLE
Minor improvement to tproxy documentation.

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -41,7 +41,7 @@ Supports:
 
 * IPv4 TCP
 * IPv4 UDP
-* IPv6 DNS
+* IPv4 DNS
 * IPv6 TCP
 * IPv6 UDP
 * IPv6 DNS

--- a/docs/tproxy.rst
+++ b/docs/tproxy.rst
@@ -1,6 +1,6 @@
 TPROXY
 ======
-TPROXY is the only method that has full support of IPv6 and UDP.
+TPROXY is the only method that supports UDP.
 
 There are some things you need to consider for TPROXY to work:
 


### PR DESCRIPTION
Previously, tproxy was unique in its support of IPv6. Now, many
sshuttle methods support IPv6 and tproxy remains the only option that
supports UDP.