### PR TITLE
Fix DNS capture issue on systemd based OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /.pytest_cache/
 /.python-version
 .vscode/
+.idea/

--- a/sshuttle/helpers.py
+++ b/sshuttle/helpers.py
@@ -89,7 +89,7 @@ def resolvconf_nameservers(systemd_resolved):
     # second file will fail.
     files = ['/etc/resolv.conf']
     if systemd_resolved:
-        # If it's systemd based system - do not capture the stub service. Only remote servers
+        # If it's systemd based system - do not capture the stub service
         files = ['/run/systemd/resolve/resolv.conf']
 
     nsservers = []

--- a/sshuttle/helpers.py
+++ b/sshuttle/helpers.py
@@ -89,7 +89,8 @@ def resolvconf_nameservers(systemd_resolved):
     # second file will fail.
     files = ['/etc/resolv.conf']
     if systemd_resolved:
-        files += ['/run/systemd/resolve/resolv.conf']
+        # If it's systemd based system - do not capture the stub service. Only remote servers
+        files = ['/run/systemd/resolve/resolv.conf']
 
     nsservers = []
     for f in files:


### PR DESCRIPTION
On systemd based systems /etc/resolve.conf contains only the link to localhost.
This forces all dns requests to be sent to the systemd DNS subsystem on 12.0.0.1.
Capturing DNS requests to 127.0.0.1 will result in an endless loop and will prevent any DNS names from being resolved.

This fix ensures that we only capture remote DNS requests, preserving the systemd dns proxy.