### PR TITLE
Clarify --disable-ipv6 in man page.

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -242,8 +242,8 @@ Options
 
 .. option:: --disable-ipv6
 
-    Disable IPv6 support for methods that support it (nft, tproxy, and
-    pf).
+    Disable IPv6 support for methods that support it (nat, nft,
+    tproxy, and pf).
 
 .. option:: --firewall
 


### PR DESCRIPTION
The description for --disable-ipv6 did not list all methods that
support IPv6.