### PR TITLE
Add tests for host name resolution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ identity=0x1784577F811F6EAC
 count=true
 show-source=true
 statistics=true
+max-line-length=128
 
 [tool:pytest]
 addopts = --cov=sshuttle --cov-branch --cov-report=term-missing

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -1,5 +1,6 @@
 import socket
 from argparse import ArgumentTypeError as Fatal
+from unittest.mock import patch
 
 import pytest
 
@@ -116,7 +117,8 @@ def test_convert_arg_line_to_args_skips_comments():
     assert parser.convert_arg_line_to_args("# whatever something") == []
 
 
-def test_parse_subnetport_host():
+@patch('sshuttle.options.socket.getaddrinfo', side_effect = _mock_getaddrinfo)
+def test_parse_subnetport_host(mock_getaddrinfo):
     assert set(sshuttle.options.parse_subnetport('example.com')) \
         == set([
             (socket.AF_INET6, '2606:2800:220:1:248:1893:25c8:1946', 128, 0, 0),
@@ -124,7 +126,8 @@ def test_parse_subnetport_host():
         ])
 
 
-def test_parse_subnetport_host_with_port():
+@patch('sshuttle.options.socket.getaddrinfo', side_effect = _mock_getaddrinfo)
+def test_parse_subnetport_host_with_port(mock_getaddrinfo):
     assert set(sshuttle.options.parse_subnetport('example.com:80')) \
         == set([
             (socket.AF_INET6, '2606:2800:220:1:248:1893:25c8:1946', 128, 80, 80),

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -113,3 +113,16 @@ def test_parse_subnetport_host():
             (socket.AF_INET6, '2606:2800:220:1:248:1893:25c8:1946', 128, 0, 0),
             (socket.AF_INET, '93.184.216.34', 32, 0, 0),
         ])
+
+
+def test_parse_subnetport_host_with_port():
+    assert set(sshuttle.options.parse_subnetport('example.com:80')) \
+        == set([
+            (socket.AF_INET6, '2606:2800:220:1:248:1893:25c8:1946', 128, 80, 80),
+            (socket.AF_INET, '93.184.216.34', 32, 80, 80),
+        ])
+    assert set(sshuttle.options.parse_subnetport('example.com:80-90')) \
+        == set([
+            (socket.AF_INET6, '2606:2800:220:1:248:1893:25c8:1946', 128, 80, 90),
+            (socket.AF_INET, '93.184.216.34', 32, 80, 90),
+        ])

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -27,6 +27,15 @@ _ip6_reprs = {
 _ip6_swidths = (48, 64, 96, 115, 128)
 
 
+def _mock_getaddrinfo(host, *_):
+    return {
+        "example.com": [
+            (socket.AF_INET6, socket.SOCK_STREAM, 0, '', ('2606:2800:220:1:248:1893:25c8:1946', 0, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, '', ('93.184.216.34', 0)),
+        ],
+    }.get(host, [])
+
+
 def test_parse_subnetport_ip4():
     for ip_repr, ip in _ip4_reprs.items():
         assert sshuttle.options.parse_subnetport(ip_repr) \

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -121,7 +121,7 @@ def test_convert_arg_line_to_args_skips_comments():
     assert parser.convert_arg_line_to_args("# whatever something") == []
 
 
-@patch('sshuttle.options.socket.getaddrinfo', side_effect = _mock_getaddrinfo)
+@patch('sshuttle.options.socket.getaddrinfo', side_effect=_mock_getaddrinfo)
 def test_parse_subnetport_host(mock_getaddrinfo):
     assert set(sshuttle.options.parse_subnetport('example.com')) \
         == set([
@@ -135,7 +135,7 @@ def test_parse_subnetport_host(mock_getaddrinfo):
         ])
 
 
-@patch('sshuttle.options.socket.getaddrinfo', side_effect = _mock_getaddrinfo)
+@patch('sshuttle.options.socket.getaddrinfo', side_effect=_mock_getaddrinfo)
 def test_parse_subnetport_host_with_port(mock_getaddrinfo):
     assert set(sshuttle.options.parse_subnetport('example.com:80')) \
         == set([

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -34,6 +34,10 @@ def _mock_getaddrinfo(host, *_):
             (socket.AF_INET6, socket.SOCK_STREAM, 0, '', ('2606:2800:220:1:248:1893:25c8:1946', 0, 0, 0)),
             (socket.AF_INET, socket.SOCK_STREAM, 0, '', ('93.184.216.34', 0)),
         ],
+        "my.local": [
+            (socket.AF_INET6, socket.SOCK_STREAM, 0, '', ('::1', 0, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 0, '', ('127.0.0.1', 0)),
+        ],
     }.get(host, [])
 
 
@@ -124,6 +128,11 @@ def test_parse_subnetport_host(mock_getaddrinfo):
             (socket.AF_INET6, '2606:2800:220:1:248:1893:25c8:1946', 128, 0, 0),
             (socket.AF_INET, '93.184.216.34', 32, 0, 0),
         ])
+    assert set(sshuttle.options.parse_subnetport('my.local')) \
+        == set([
+            (socket.AF_INET6, '::1', 128, 0, 0),
+            (socket.AF_INET, '127.0.0.1', 32, 0, 0),
+        ])
 
 
 @patch('sshuttle.options.socket.getaddrinfo', side_effect = _mock_getaddrinfo)
@@ -137,4 +146,14 @@ def test_parse_subnetport_host_with_port(mock_getaddrinfo):
         == set([
             (socket.AF_INET6, '2606:2800:220:1:248:1893:25c8:1946', 128, 80, 90),
             (socket.AF_INET, '93.184.216.34', 32, 80, 90),
+        ])
+    assert set(sshuttle.options.parse_subnetport('my.local:445')) \
+        == set([
+            (socket.AF_INET6, '::1', 128, 445, 445),
+            (socket.AF_INET, '127.0.0.1', 32, 445, 445),
+        ])
+    assert set(sshuttle.options.parse_subnetport('my.local:445-450')) \
+        == set([
+            (socket.AF_INET6, '::1', 128, 445, 450),
+            (socket.AF_INET, '127.0.0.1', 32, 445, 450),
         ])

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -105,3 +105,11 @@ def test_parse_subnetport_ip6_with_mask_and_port():
 def test_convert_arg_line_to_args_skips_comments():
     parser = sshuttle.options.MyArgumentParser()
     assert parser.convert_arg_line_to_args("# whatever something") == []
+
+
+def test_parse_subnetport_host():
+    assert set(sshuttle.options.parse_subnetport('example.com')) \
+        == set([
+            (socket.AF_INET6, '2606:2800:220:1:248:1893:25c8:1946', 128, 0, 0),
+            (socket.AF_INET, '93.184.216.34', 32, 0, 0),
+        ])


### PR DESCRIPTION
I'd like to touch the subnet option parser (at `options.py`).
However, I found some test cases for that are missing.
I believe we should test it can parse and resolve host names.

Hope you accept and merge this.

Thank you,