### PR TITLE
avoid moving/renaming the hosts file - fix docker container issue

### DIFF
--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -1,4 +1,5 @@
 import errno
+import shutil
 import socket
 import signal
 import sys
@@ -30,7 +31,10 @@ def rewrite_etc_hosts(hostmap, port):
         else:
             raise
     if old_content.strip() and not os.path.exists(BAKFILE):
-        os.link(HOSTSFILE, BAKFILE)
+        try:
+            os.link(HOSTSFILE, BAKFILE)
+        except OSError:
+            shutil.copyfile(HOSTSFILE, BAKFILE)
     tmpname = "%s.%d.tmp" % (HOSTSFILE, port)
     f = open(tmpname, 'w')
     for line in old_content.rstrip().split('\n'):
@@ -47,7 +51,10 @@ def rewrite_etc_hosts(hostmap, port):
     else:
         os.chown(tmpname, 0, 0)
         os.chmod(tmpname, 0o600)
-    os.rename(tmpname, HOSTSFILE)
+    try:
+        os.rename(tmpname, HOSTSFILE)
+    except OSError:
+        shutil.move(tmpname, HOSTSFILE)
 
 
 def restore_etc_hosts(hostmap, port):

--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -34,6 +34,7 @@ def rewrite_etc_hosts(hostmap, port):
         try:
             os.link(HOSTSFILE, BAKFILE)
         except OSError:
+            # file is locked - performing non-atomic copy
             shutil.copyfile(HOSTSFILE, BAKFILE)
     tmpname = "%s.%d.tmp" % (HOSTSFILE, port)
     f = open(tmpname, 'w')
@@ -54,6 +55,9 @@ def rewrite_etc_hosts(hostmap, port):
     try:
         os.rename(tmpname, HOSTSFILE)
     except OSError:
+        # file is locked - performing non-atomic copy
+        log('Warning: Using a non-atomic way to overwrite %s that can corrupt the file if '
+            'multiple processes write to it simultaneously.' % HOSTSFILE)
         shutil.move(tmpname, HOSTSFILE)
 
 


### PR DESCRIPTION
Docker mounts the `/etc/hosts` file when running a container. 
The rest of the /etc folder is not mounted on the same mountpoint as the hosts file.

`sshuttle` is trying to backup the file by creating a hard link. 
Hard links in linux require the files to be in the same mount. 

There does not seem to be a reason a hard link is generated just for a backup. 
Also, after the backup is captured `sshuttle` tries to overwrite the hosts file by `os.rename(TMPFILE, HOSTSFILE)`.

In docker containers the hosts file is mounted and is not allowed to be manipulated resulting in a `Resource Busy` error.
However the user can edit the file normally by manipulating the content of the file.

**THIS PR:**
- copies the `/etc/hosts` to `/etc/hosts.sbak` instead of creating a hard link
- opens the `/etc/hosts` file and writes the contents of `/etc/hosts.XXX.tmp` file instead of using `os.rename` to overwrite the file

**Troubleshooting - my problem:**
I had this problem with my container and patched the problem with this PR.
- I was receiving a `OSError: [Errno 18] Cross-device link: '/etc/hosts' -> '/etc/hosts.sbak'`. 
- I initially created a placeholder file since I didn't care about a backup in a container
- Then the tmp file that contained the DNS entries could not be stored in the `/etc/hosts` file because the file could not be overwritten(not allowed by docker)
- Then i commented out the `os.rename(tmpname, HOSTSFILE)` on firewall.py:L50
- The tunneling worked but i was missing the DNS entries from the hosts file
- So, I made this PR to write to the existing file instead of overwritting the file 