### PR TITLE
Fix incorrect permissions for /etc/hosts

### DIFF
--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -51,7 +51,7 @@ def rewrite_etc_hosts(hostmap, port):
         os.chmod(tmpname, st.st_mode)
     else:
         os.chown(tmpname, 0, 0)
-        os.chmod(tmpname, 0o600)
+        os.chmod(tmpname, 0o644)
     try:
         os.rename(tmpname, HOSTSFILE)
     except OSError:


### PR DESCRIPTION
If we modify /etc/hosts, we read/copy the ownership and permissions
from the existing /etc/hosts before we make our new temporary file
which will eventually overwrite /etc/hosts. If we fail to retrieve the
permissions of the existing /etc/hosts file, we made the temporary
file owned by root 0o600 permissions. It should have 0o644 permissions
so that /etc/hosts has the correct permissions once we rename it.

It is unlikely many encoutered this bug since most machines have
/etc/hosts prior to sshuttle running and we should be able to read the
permission/ownership of that existing file.