### PR TITLE
This test broke in Python3.11

### DIFF
--- a/tests/client/test_helpers.py
+++ b/tests/client/test_helpers.py
@@ -192,5 +192,4 @@ def test_family_ip_tuple():
 def test_family_to_string():
     assert sshuttle.helpers.family_to_string(AF_INET) == "AF_INET"
     assert sshuttle.helpers.family_to_string(AF_INET6) == "AF_INET6"
-    expected = 'AddressFamily.AF_UNIX'
-    assert sshuttle.helpers.family_to_string(socket.AF_UNIX) == expected
+    assert isinstance(sshuttle.helpers.family_to_string(socket.AF_UNIX), str)


### PR DESCRIPTION
Fixed the test and only check for instance: str for families that are
not explicitly covered in `family_to_str`

closes: #784