### PR TITLE
Replace setuptools_scm with bump2version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/sshuttle/version.py
 /tmp/
 /.cache/
 /.eggs/

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,3 +3,4 @@ pytest==7.1.2
 pytest-cov==3.0.0
 flake8==5.0.4
 pyflakes==2.5.0
+bump2version==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-setuptools-scm==7.0.5
 Sphinx==5.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,23 @@
+[bumpversion]
+current_version = 1.1.0
+
+[bumpversion:file:sshuttle/version.py]
+
 [aliases]
-test=pytest
+test = pytest
 
 [bdist_wheel]
 universal = 1
 
 [upload]
-sign=true
-identity=0x1784577F811F6EAC
+sign = true
+identity = 0x1784577F811F6EAC
 
 [flake8]
-count=true
-show-source=true
-statistics=true
-max-line-length=128
+count = true
+show-source = true
+statistics = true
+max-line-length = 128
 
 [tool:pytest]
 addopts = --cov=sshuttle --cov-branch --cov-report=term-missing

--- a/setup.py
+++ b/setup.py
@@ -20,19 +20,8 @@
 from setuptools import setup, find_packages
 
 
-def version_scheme(version):
-    from setuptools_scm.version import guess_next_dev_version
-    version = guess_next_dev_version(version)
-    return version.lstrip("v")
-
-
 setup(
     name="sshuttle",
-    use_scm_version={
-        'write_to': "sshuttle/version.py",
-        'version_scheme': version_scheme,
-    },
-    setup_requires=['setuptools_scm'],
     # version=version,
     url='https://github.com/sshuttle/sshuttle',
     author='Brian May',

--- a/sshuttle/version.py
+++ b/sshuttle/version.py
@@ -1,0 +1,1 @@
+__version__ = version = '1.1.0'


### PR DESCRIPTION
As requested in #754, this PR replaces setuptools_scm with `bump2version`.

You'll notice that `sshuttle/version.py` is now under version control, this is intentional.

## How to use?

Whenever you want to bump the version just:

```sh
bumpversion patch
```

or

```sh
bumpversion minor
```

depending on which part of the version you'll want to bump. This will update the `sshuttle/version.py`  and the `setup.cfg` and requires a new commit. That's all.

I wasn't sure where to add the dependency to `bump2version` so I added it to `requirements-test.txt`, assuming that this is more correct than the `requirements.txt`.



