### PR TITLE
Unbreak OpenBSD runtime.

### DIFF
--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -266,7 +266,7 @@ class OpenBsd(Generic):
                         ("proto_variant", c_uint8),
                         ("direction", c_uint8)]
 
-        self.pfioc_rule = c_char * 3424
+        self.pfioc_rule = c_char * 3408
         self.pfioc_natlook = pfioc_natlook
         super(OpenBsd, self).__init__()
 

--- a/tests/client/test_methods_pf.py
+++ b/tests/client/test_methods_pf.py
@@ -411,8 +411,8 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         '0x01')
 
     assert mock_ioctl.mock_calls == [
-        call(mock_pf_get_dev(), 0xcd60441a, ANY),
-        call(mock_pf_get_dev(), 0xcd60441a, ANY),
+        call(mock_pf_get_dev(), 0xcd50441a, ANY),
+        call(mock_pf_get_dev(), 0xcd50441a, ANY),
     ]
     assert mock_pfctl.mock_calls == [
         call('-s Interfaces -i lo -v'),
@@ -461,8 +461,8 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         None,
         '0x01')
     assert mock_ioctl.mock_calls == [
-        call(mock_pf_get_dev(), 0xcd60441a, ANY),
-        call(mock_pf_get_dev(), 0xcd60441a, ANY),
+        call(mock_pf_get_dev(), 0xcd50441a, ANY),
+        call(mock_pf_get_dev(), 0xcd50441a, ANY),
     ]
     assert mock_pfctl.mock_calls == [
         call('-s Interfaces -i lo -v'),


### PR DESCRIPTION
sizeof(struct pfioc_rule) changed in recent OpenBSD releases. This fixes the ioctl call to DIOCCHANGERULE.