### PR TITLE
fix 2 deadlocks involved in hostwatch feature

### DIFF
--- a/sshuttle/helpers.py
+++ b/sshuttle/helpers.py
@@ -12,9 +12,10 @@ def b(s):
 
 
 def log(s):
-    global logprefix
+    global logprefix, isforkedchild
     try:
-        sys.stdout.flush()
+        if not isforkedchild:
+            sys.stdout.flush()
         # Put newline at end of string if line doesn't have one.
         if not s.endswith("\n"):
             s = s+"\n"
@@ -31,7 +32,8 @@ def log(s):
             # to cause problems elsewhere.
             sys.stderr.write(prefix + line + "\r\n")
             prefix = "    "
-        sys.stderr.flush()
+        if not isforkedchild:
+            sys.stderr.flush()
     except IOError:
         # this could happen if stderr gets forcibly disconnected, eg. because
         # our tty closes.  That sucks, but it's no reason to abort the program.

--- a/sshuttle/hostwatch.py
+++ b/sshuttle/hostwatch.py
@@ -16,6 +16,7 @@ NETSTAT_POLL_TIME = 30
 CACHEFILE = os.path.expanduser('~/.sshuttle.hosts')
 
 # Have we already failed to write CACHEFILE?
+SHOULD_WRITE_CACHE = False
 CACHE_WRITE_FAILED = False
 
 hostnames = {}
@@ -81,6 +82,9 @@ def read_host_cache():
             ip = re.sub(r'[^0-9.]', '', ip).strip()
             if name and ip:
                 found_host(name, ip)
+    f.close()
+    if SHOULD_WRITE_CACHE:
+        write_host_cache()
 
 
 def found_host(name, ip):
@@ -102,7 +106,7 @@ def found_host(name, ip):
         hostnames[name] = ip
         debug1('Found: %s: %s' % (name, ip))
         sys.stdout.write('%s,%s\n' % (name, ip))
-        write_host_cache()
+        SHOULD_WRITE_CACHE = True
 
 
 def _check_etc_hosts():

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -120,8 +120,10 @@ def _exc_dump():
 
 
 def start_hostwatch(seed_hosts, auto_hosts):
+    global isforkedchild
     s1, s2 = socket.socketpair()
     pid = os.fork()
+    isforkedchild = not pid
     if not pid:
         # child
         rv = 99


### PR DESCRIPTION
1st deadlock: 
child process (to run hw_main()) and parent process may both try to flush stdout during logging, leading to hw_main() locking (and thus, not finishing its work of adding discovered hosts)

2nd deadlock:
in hostwatch.py, during reading of host cache file (while its fd is open), another temp file is written but then moved onto the host cache file (but this can't complete til the fd is closed, which won't happen since this call is in the stack originating during the reading of the file)

Both of these issues caused the host watch process to freeze partway - randomly - resulting in the need to repeatedly re-run the program til it happened to not hit the deadlock. This is particularly noticeable for long host cache files with many domains in them. 