### PR TITLE
fix 2 deadlocks involved in hostwatch feature

### DIFF
--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -6,11 +6,14 @@ import sshuttle.firewall as firewall
 import sshuttle.hostwatch as hostwatch
 import sshuttle.ssyslog as ssyslog
 from sshuttle.options import parser, parse_ipport
-from sshuttle.helpers import family_ip_tuple, log, Fatal
+from sshuttle.helpers import family_ip_tuple, log, Fatal, start_stdout_stderr_flush_thread
 from sshuttle.sudoers import sudoers
 
 
 def main():
+
+    start_stdout_stderr_flush_thread()
+
     opt = parser.parse_args()
 
     if opt.sudoers_no_modify:

--- a/sshuttle/helpers.py
+++ b/sshuttle/helpers.py
@@ -12,15 +12,18 @@ verbose = 0
 def b(s):
     return s.encode("ASCII")
 
+
 def flush_loop():
     while True:
         sys.stdout.flush()
         sys.stderr.flush()
         time.sleep(0.5)
 
+
 def start_stdout_stderr_flush_thread():
     flush_thread = threading.Thread(target=flush_loop)
     flush_thread.start()
+
 
 def log(s):
     global logprefix

--- a/sshuttle/helpers.py
+++ b/sshuttle/helpers.py
@@ -2,6 +2,8 @@ import sys
 import socket
 import errno
 import os
+import threading
+import time
 
 logprefix = ''
 verbose = 0
@@ -10,11 +12,19 @@ verbose = 0
 def b(s):
     return s.encode("ASCII")
 
+def flush_loop():
+    while True:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        time.sleep(0.5)
+
+def start_stdout_stderr_flush_thread():
+    flush_thread = threading.Thread(target=flush_loop)
+    flush_thread.start()
 
 def log(s):
     global logprefix
     try:
-        sys.stdout.flush()
         # Put newline at end of string if line doesn't have one.
         if not s.endswith("\n"):
             s = s+"\n"
@@ -31,7 +41,6 @@ def log(s):
             # to cause problems elsewhere.
             sys.stderr.write(prefix + line + "\r\n")
             prefix = "    "
-        sys.stderr.flush()
     except IOError:
         # this could happen if stderr gets forcibly disconnected, eg. because
         # our tty closes.  That sucks, but it's no reason to abort the program.

--- a/sshuttle/hostwatch.py
+++ b/sshuttle/hostwatch.py
@@ -104,6 +104,7 @@ def found_host(name, ip):
     if hostname != name:
         found_host(hostname, ip)
 
+    global SHOULD_WRITE_CACHE
     oldip = hostnames.get(name)
     if oldip != ip:
         hostnames[name] = ip

--- a/sshuttle/hostwatch.py
+++ b/sshuttle/hostwatch.py
@@ -84,6 +84,7 @@ def read_host_cache():
             if name and ip:
                 found_host(name, ip)
     f.close()
+    global SHOULD_WRITE_CACHE
     if SHOULD_WRITE_CACHE:
         write_host_cache()
         SHOULD_WRITE_CACHE = False

--- a/sshuttle/hostwatch.py
+++ b/sshuttle/hostwatch.py
@@ -18,6 +18,8 @@ CACHEFILE = os.path.expanduser('~/.sshuttle.hosts')
 # Have we already failed to write CACHEFILE?
 CACHE_WRITE_FAILED = False
 
+SHOULD_WRITE_CACHE = False
+
 hostnames = {}
 queue = {}
 try:
@@ -81,6 +83,10 @@ def read_host_cache():
             ip = re.sub(r'[^0-9.]', '', ip).strip()
             if name and ip:
                 found_host(name, ip)
+    f.close()
+    if SHOULD_WRITE_CACHE:
+        write_host_cache()
+        SHOULD_WRITE_CACHE = False
 
 
 def found_host(name, ip):
@@ -102,7 +108,7 @@ def found_host(name, ip):
         hostnames[name] = ip
         debug1('Found: %s: %s' % (name, ip))
         sys.stdout.write('%s,%s\n' % (name, ip))
-        write_host_cache()
+        SHOULD_WRITE_CACHE = True
 
 
 def _check_etc_hosts():

--- a/tests/client/test_helpers.py
+++ b/tests/client/test_helpers.py
@@ -2,6 +2,7 @@ import io
 import socket
 from socket import AF_INET, AF_INET6
 import errno
+import time
 
 from unittest.mock import patch, call
 import sshuttle.helpers
@@ -16,29 +17,22 @@ def test_log(mock_stderr, mock_stdout):
     sshuttle.helpers.log("message 1\n")
     sshuttle.helpers.log("message 2\nline2\nline3\n")
     sshuttle.helpers.log("message 3\nline2\nline3")
-    assert mock_stdout.mock_calls == [
-        call.flush(),
-        call.flush(),
-        call.flush(),
-        call.flush(),
-        call.flush(),
-    ]
-    assert mock_stderr.mock_calls == [
+    time.Sleep(1)
+    assert call.flush() in mock_stdout.mock_calls
+    stderr_contents = [
         call.write('prefix: message\r\n'),
-        call.flush(),
         call.write('prefix: abc\r\n'),
-        call.flush(),
         call.write('prefix: message 1\r\n'),
-        call.flush(),
         call.write('prefix: message 2\r\n'),
         call.write('    line2\r\n'),
         call.write('    line3\r\n'),
-        call.flush(),
         call.write('prefix: message 3\r\n'),
         call.write('    line2\r\n'),
         call.write('    line3\r\n'),
-        call.flush(),
+        call.flush()
     ]
+    for line in stderr_contents:
+        assert line in mock_stderr.mock_calls
 
 
 @patch('sshuttle.helpers.logprefix', new='prefix: ')
@@ -47,13 +41,14 @@ def test_log(mock_stderr, mock_stdout):
 @patch('sshuttle.helpers.sys.stderr')
 def test_debug1(mock_stderr, mock_stdout):
     sshuttle.helpers.debug1("message")
-    assert mock_stdout.mock_calls == [
-        call.flush(),
-    ]
-    assert mock_stderr.mock_calls == [
+    time.Sleep(1)
+    assert call.flush() in mock_stdout.mock_calls
+    stderr_contents = [
         call.write('prefix: message\r\n'),
         call.flush(),
     ]
+    for line in stderr_contents:
+        assert line in mock_stderr.mock_calls
 
 
 @patch('sshuttle.helpers.logprefix', new='prefix: ')
@@ -72,13 +67,14 @@ def test_debug1_nop(mock_stderr, mock_stdout):
 @patch('sshuttle.helpers.sys.stderr')
 def test_debug2(mock_stderr, mock_stdout):
     sshuttle.helpers.debug2("message")
-    assert mock_stdout.mock_calls == [
-        call.flush(),
-    ]
-    assert mock_stderr.mock_calls == [
+    assert call.flush() in mock_stdout.mock_calls
+    time.Sleep(1)
+    stderr_contents = [
         call.write('prefix: message\r\n'),
         call.flush(),
     ]
+    for line in stderr_contents:
+        assert line in mock_stderr.mock_calls
 
 
 @patch('sshuttle.helpers.logprefix', new='prefix: ')
@@ -97,13 +93,14 @@ def test_debug2_nop(mock_stderr, mock_stdout):
 @patch('sshuttle.helpers.sys.stderr')
 def test_debug3(mock_stderr, mock_stdout):
     sshuttle.helpers.debug3("message")
-    assert mock_stdout.mock_calls == [
-        call.flush(),
-    ]
-    assert mock_stderr.mock_calls == [
+    time.Sleep(1)
+    assert call.flush() in mock_stdout.mock_calls
+    stderr_contents = [
         call.write('prefix: message\r\n'),
         call.flush(),
     ]
+    for line in stderr_contents:
+        assert line in mock_stderr.mock_calls
 
 
 @patch('sshuttle.helpers.logprefix', new='prefix: ')

--- a/tests/client/test_helpers.py
+++ b/tests/client/test_helpers.py
@@ -17,7 +17,7 @@ def test_log(mock_stderr, mock_stdout):
     sshuttle.helpers.log("message 1\n")
     sshuttle.helpers.log("message 2\nline2\nline3\n")
     sshuttle.helpers.log("message 3\nline2\nline3")
-    time.Sleep(1)
+    time.sleep(1)
     assert call.flush() in mock_stdout.mock_calls
     stderr_contents = [
         call.write('prefix: message\r\n'),
@@ -41,7 +41,7 @@ def test_log(mock_stderr, mock_stdout):
 @patch('sshuttle.helpers.sys.stderr')
 def test_debug1(mock_stderr, mock_stdout):
     sshuttle.helpers.debug1("message")
-    time.Sleep(1)
+    time.sleep(1)
     assert call.flush() in mock_stdout.mock_calls
     stderr_contents = [
         call.write('prefix: message\r\n'),
@@ -67,8 +67,8 @@ def test_debug1_nop(mock_stderr, mock_stdout):
 @patch('sshuttle.helpers.sys.stderr')
 def test_debug2(mock_stderr, mock_stdout):
     sshuttle.helpers.debug2("message")
+    time.sleep(1)
     assert call.flush() in mock_stdout.mock_calls
-    time.Sleep(1)
     stderr_contents = [
         call.write('prefix: message\r\n'),
         call.flush(),
@@ -93,7 +93,7 @@ def test_debug2_nop(mock_stderr, mock_stdout):
 @patch('sshuttle.helpers.sys.stderr')
 def test_debug3(mock_stderr, mock_stdout):
     sshuttle.helpers.debug3("message")
-    time.Sleep(1)
+    time.sleep(1)
     assert call.flush() in mock_stdout.mock_calls
     stderr_contents = [
         call.write('prefix: message\r\n'),


### PR DESCRIPTION
1st deadlock:
child process (to run hw_main()) and parent process may both try to flush stdout during logging, leading to hw_main() locking (and thus, not finishing its work of adding discovered hosts)

2nd deadlock:
in hostwatch.py, during reading of host cache file (while its fd is open), another temp file is written but then moved onto the host cache file (but this can't complete til the fd is closed, which won't happen since this call is in the stack originating during the reading of the file)

Both of these issues caused the host watch process to freeze partway - randomly - resulting in the need to repeatedly re-run the program til it happened to not hit the deadlock. This is particularly noticeable for long host cache files with many domains in them.

Solution:

- 1: stdout/stderr are now only flushed in a threaded loop launched by main
- 2: the *need* to write the host cache file is flagged where previously the write itself was attempted (during reading!). When reading is complete and the file is closed, then the write occurs.