### PR TITLE
Support gid-based routing and allow tunnel localhost ports  

### DIFF
--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -21,6 +21,10 @@ try:
     from pwd import getpwnam
 except ImportError:
     getpwnam = None
+try:
+    from grp import getgrnam
+except ImportError:
+    getgrnam = None
 
 import socket
 
@@ -726,7 +730,7 @@ def main(listenip_v6, listenip_v4,
          latency_buffer_size, dns, nslist,
          method_name, seed_hosts, auto_hosts, auto_nets,
          subnets_include, subnets_exclude, daemon, to_nameserver, pidfile,
-         user, sudo_pythonpath, tmark):
+         user, group, sudo_pythonpath, tmark):
 
     if not remotename:
         raise Fatal("You must use -r/--remote to specify a remote "
@@ -828,6 +832,15 @@ def main(listenip_v6, listenip_v4,
         except KeyError:
             raise Fatal("User %s does not exist." % user)
     required.user = False if user is None else True
+
+    if group is not None:
+        if getgrnam is None:
+            raise Fatal("Routing by group not available on this system.")
+        try:
+            group = getgrnam(group).gr_gid
+        except KeyError:
+            raise Fatal("User %s does not exist." % user)
+    required.group = False if group is None else True
 
     if not required.ipv6 and len(subnets_v6) > 0:
         print("WARNING: IPv6 subnets were ignored because IPv6 is disabled "
@@ -1058,7 +1071,7 @@ def main(listenip_v6, listenip_v4,
     # start the firewall
     fw.setup(subnets_include, subnets_exclude, nslist,
              redirectport_v6, redirectport_v4, dnsport_v6, dnsport_v4,
-             required.udp, user, tmark)
+             required.udp, user, group, tmark)
 
     # start the client process
     try:

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -319,7 +319,7 @@ class FirewallClient:
 
     def setup(self, subnets_include, subnets_exclude, nslist,
               redirectport_v6, redirectport_v4, dnsport_v6, dnsport_v4, udp,
-              user, tmark):
+              user, group, tmark):
         self.subnets_include = subnets_include
         self.subnets_exclude = subnets_exclude
         self.nslist = nslist
@@ -329,6 +329,7 @@ class FirewallClient:
         self.dnsport_v4 = dnsport_v4
         self.udp = udp
         self.user = user
+        self.group = group
         self.tmark = tmark
 
     def check(self):
@@ -367,9 +368,14 @@ class FirewallClient:
             user = bytes(self.user, 'utf-8')
         else:
             user = b'%d' % self.user
-
-        self.pfile.write(b'GO %d %s %s %d\n' %
-                         (udp, user, bytes(self.tmark, 'ascii'), os.getpid()))
+        if self.group is None:
+            group = b'-'
+        elif isinstance(self.group, str):
+            group =  bytes(self.group, 'utf-8')
+        else:
+            group = b'%d' % self.group
+        self.pfile.write(b'GO %d %s %s %s %d\n' %
+                         (udp, user, group, bytes(self.tmark, 'ascii'), os.getpid()))
         self.pfile.flush()
 
         line = self.pfile.readline()

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -104,6 +104,7 @@ def main():
                                       opt.to_ns,
                                       opt.pidfile,
                                       opt.user,
+                                      opt.group,
                                       opt.sudo_pythonpath,
                                       opt.tmark)
 

--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -270,13 +270,15 @@ def main(method_name, syslog):
 
     _, _, args = line.partition(" ")
     global sshuttle_pid
-    udp, user, tmark, sshuttle_pid = args.strip().split(" ", 3)
+    udp, user, group, tmark, sshuttle_pid = args.strip().split(" ", 4)
     udp = bool(int(udp))
     sshuttle_pid = int(sshuttle_pid)
     if user == '-':
         user = None
-    debug2('Got udp: %r, user: %r, tmark: %s, sshuttle_pid: %d' %
-           (udp, user, tmark, sshuttle_pid))
+    if group == '-':
+        group = None
+    debug2('Got udp: %r, user: %r, group: %r, tmark: %s, sshuttle_pid: %d' %
+           (udp, user, group, tmark, sshuttle_pid))
 
     subnets_v6 = [i for i in subnets if i[0] == socket.AF_INET6]
     nslist_v6 = [i for i in nslist if i[0] == socket.AF_INET6]
@@ -291,14 +293,14 @@ def main(method_name, syslog):
             method.setup_firewall(
                 port_v6, dnsport_v6, nslist_v6,
                 socket.AF_INET6, subnets_v6, udp,
-                user, tmark)
+                user, group, tmark)
 
         if subnets_v4 or nslist_v4:
             debug2('setting up IPv4.')
             method.setup_firewall(
                 port_v4, dnsport_v4, nslist_v4,
                 socket.AF_INET, subnets_v4, udp,
-                user, tmark)
+                user, group, tmark)
 
         flush_systemd_dns_cache()
         stdout.write('STARTED\n')
@@ -334,7 +336,7 @@ def main(method_name, syslog):
         try:
             if subnets_v6 or nslist_v6:
                 debug2('undoing IPv6 changes.')
-                method.restore_firewall(port_v6, socket.AF_INET6, udp, user)
+                method.restore_firewall(port_v6, socket.AF_INET6, udp, user, group)
         except Exception:
             try:
                 debug1("Error trying to undo IPv6 firewall.")
@@ -345,7 +347,7 @@ def main(method_name, syslog):
         try:
             if subnets_v4 or nslist_v4:
                 debug2('undoing IPv4 changes.')
-                method.restore_firewall(port_v4, socket.AF_INET, udp, user)
+                method.restore_firewall(port_v4, socket.AF_INET, udp, user, group)
         except Exception:
             try:
                 debug1("Error trying to undo IPv4 firewall.")

--- a/sshuttle/methods/__init__.py
+++ b/sshuttle/methods/__init__.py
@@ -90,10 +90,10 @@ class BaseMethod(object):
                     (key, self.name))
 
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
-                       user, tmark):
+                       user, group, tmark):
         raise NotImplementedError()
 
-    def restore_firewall(self, port, family, udp, user):
+    def restore_firewall(self, port, family, udp, user, group):
         raise NotImplementedError()
 
     @staticmethod

--- a/sshuttle/methods/__init__.py
+++ b/sshuttle/methods/__init__.py
@@ -50,6 +50,7 @@ class BaseMethod(object):
         result.udp = False
         result.dns = True
         result.user = False
+        result.group = False
         return result
 
     @staticmethod

--- a/sshuttle/methods/ipfw.py
+++ b/sshuttle/methods/ipfw.py
@@ -156,7 +156,7 @@ class Method(BaseMethod):
         #     udp_listener.v6.setsockopt(SOL_IPV6, IPV6_RECVDSTADDR, 1)
 
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
-                       user, tmark):
+                       user, group, tmark):
         # IPv6 not supported
         if family not in [socket.AF_INET]:
             raise Exception(
@@ -207,7 +207,7 @@ class Method(BaseMethod):
                 else:
                     ipfw('table', '126', 'add', '%s/%s' % (snet, swidth))
 
-    def restore_firewall(self, port, family, udp, user):
+    def restore_firewall(self, port, family, udp, user, group):
         if family not in [socket.AF_INET]:
             raise Exception(
                 'Address family "%s" unsupported by ipfw method'

--- a/sshuttle/methods/nat.py
+++ b/sshuttle/methods/nat.py
@@ -59,11 +59,6 @@ class Method(BaseMethod):
                  '--dport', '53',
                  '--to-ports', str(dnsport))
 
-        # Don't route any remaining local traffic through sshuttle.
-        _ipt('-A', chain, '-j', 'RETURN',
-             '-m', 'addrtype',
-             '--dst-type', 'LOCAL')
-
         # create new subnet entries.
         for _, swidth, sexclude, snet, fport, lport \
                 in sorted(subnets, key=subnet_weight, reverse=True):
@@ -79,6 +74,11 @@ class Method(BaseMethod):
                 _ipt('-A', chain, '-j', 'REDIRECT',
                      '--dest', '%s/%s' % (snet, swidth),
                      *(tcp_ports + ('--to-ports', str(port))))
+        
+        # Don't route any remaining local traffic through sshuttle.
+        _ipt('-A', chain, '-j', 'RETURN',
+             '-m', 'addrtype',
+             '--dst-type', 'LOCAL')
 
     def restore_firewall(self, port, family, udp, user, group):
         # only ipv4 supported with NAT

--- a/sshuttle/methods/nat.py
+++ b/sshuttle/methods/nat.py
@@ -31,17 +31,17 @@ class Method(BaseMethod):
         chain = 'sshuttle-%s' % port
 
         # basic cleanup/setup of chains
-        self.restore_firewall(port, family, udp, user)
+        self.restore_firewall(port, family, udp, user, group)
 
         _ipt('-N', chain)
         _ipt('-F', chain)
         if user is not None or group is not None:
             margs = ['-I', 'OUTPUT', '1', '-m', 'owner']
             if user is not None:
-                margs.append('--uid-owner', str(user))
+                margs += ['--uid-owner', str(user)]
             if group is not None:
-                margs.append('--gid-owner', str(group))
-            margs = args.append('-j', 'MARK', '--set-mark', str(port))
+                margs += ['--gid-owner', str(group)]
+            margs += ['-j', 'MARK', '--set-mark', str(port)]
             nonfatal(_ipm, *margs)
             args = '-m', 'mark', '--mark', str(port), '-j', chain
         else:
@@ -104,10 +104,10 @@ class Method(BaseMethod):
             if user is not None or group is not None:
                 margs = ['-D', 'OUTPUT', '-m', 'owner']
                 if user is not None:
-                    margs.append('--uid-owner', str(user))
+                    margs += ['--uid-owner', str(user)]
                 if group is not None:
-                    margs.append('--gid-owner', str(group))
-                margs = args.append('-j', 'MARK', '--set-mark', str(port))
+                    margs += ['--gid-owner', str(group)]
+                margs += ['-j', 'MARK', '--set-mark', str(port)]
                 nonfatal(_ipm, *margs)
 
                 args = '-m', 'mark', '--mark', str(port), '-j', chain

--- a/sshuttle/methods/nft.py
+++ b/sshuttle/methods/nft.py
@@ -13,7 +13,7 @@ class Method(BaseMethod):
     # recently-started one will win (because we use "-I OUTPUT 1" instead of
     # "-A OUTPUT").
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
-                       user, tmark):
+                       user, group, tmark):
         if udp:
             raise Exception("UDP not supported by nft")
 
@@ -87,7 +87,7 @@ class Method(BaseMethod):
                     ip_version, 'daddr %s/%s' % (snet, swidth),
                     ('redirect to :' + str(port)))))
 
-    def restore_firewall(self, port, family, udp, user):
+    def restore_firewall(self, port, family, udp, user, group):
         if udp:
             raise Exception("UDP not supported by nft method_name")
 

--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -448,7 +448,7 @@ class Method(BaseMethod):
         return sock.getsockname()
 
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
-                       user, tmark):
+                       user, group, tmark):
         if family not in [socket.AF_INET, socket.AF_INET6]:
             raise Exception(
                 'Address family "%s" unsupported by pf method_name'
@@ -473,7 +473,7 @@ class Method(BaseMethod):
         pf.add_rules(anchor, includes, port, dnsport, nslist, family)
         pf.enable()
 
-    def restore_firewall(self, port, family, udp, user):
+    def restore_firewall(self, port, family, udp, user, group):
         if family not in [socket.AF_INET, socket.AF_INET6]:
             raise Exception(
                 'Address family "%s" unsupported by pf method_name'

--- a/sshuttle/methods/tproxy.py
+++ b/sshuttle/methods/tproxy.py
@@ -134,7 +134,7 @@ class Method(BaseMethod):
         divert_chain = 'sshuttle-d-%s' % port
 
         # basic cleanup/setup of chains
-        self.restore_firewall(port, family, udp, user)
+        self.restore_firewall(port, family, udp, user, group)
 
         _ipt('-N', mark_chain)
         _ipt('-F', mark_chain)

--- a/sshuttle/methods/tproxy.py
+++ b/sshuttle/methods/tproxy.py
@@ -114,7 +114,7 @@ class Method(BaseMethod):
             udp_listener.v6.setsockopt(SOL_IPV6, IPV6_RECVORIGDSTADDR, 1)
 
     def setup_firewall(self, port, dnsport, nslist, family, subnets, udp,
-                       user, tmark):
+                       user, group, tmark):
         if family not in [socket.AF_INET, socket.AF_INET6]:
             raise Exception(
                 'Address family "%s" unsupported by tproxy method'
@@ -228,7 +228,7 @@ class Method(BaseMethod):
                          '-m', 'udp',
                          *(udp_ports + ('--on-port', str(port))))
 
-    def restore_firewall(self, port, family, udp, user):
+    def restore_firewall(self, port, family, udp, user, group):
         if family not in [socket.AF_INET, socket.AF_INET6]:
             raise Exception(
                 'Address family "%s" unsupported by tproxy method'

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -383,6 +383,12 @@ parser.add_argument(
     """
 )
 parser.add_argument(
+    "--group",
+    help="""
+    apply all the rules only to this linux group
+    """
+)
+parser.add_argument(
     "--firewall",
     action="store_true",
     help="""

--- a/tests/client/test_firewall.py
+++ b/tests/client/test_firewall.py
@@ -19,7 +19,7 @@ NSLIST
 {inet},1.2.3.33
 {inet6},2404:6800:4004:80c::33
 PORTS 1024,1025,1026,1027
-GO 1 - 0x01 12345
+GO 1 - - 0x01 12345
 HOST 1.2.3.3,existing
 """.format(inet=AF_INET, inet6=AF_INET6))
     stdout = Mock()

--- a/tests/client/test_firewall.py
+++ b/tests/client/test_firewall.py
@@ -145,6 +145,7 @@ def test_main(mock_get_method, mock_setup_daemon, mock_rewrite_etc_hosts):
              (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 80, 80)],
             True,
             None,
+            None,
             '0x01'),
         call().setup_firewall(
             1025, 1027,
@@ -154,7 +155,8 @@ def test_main(mock_get_method, mock_setup_daemon, mock_rewrite_etc_hosts):
              (AF_INET, 32, True, u'1.2.3.66', 8080, 8080)],
             True,
             None,
+            None,
             '0x01'),
-        call().restore_firewall(1024, AF_INET6, True, None),
-        call().restore_firewall(1025, AF_INET, True, None),
+        call().restore_firewall(1024, AF_INET6, True, None, None),
+        call().restore_firewall(1025, AF_INET, True, None, None),
     ]

--- a/tests/client/test_methods_nat.py
+++ b/tests/client/test_methods_nat.py
@@ -101,6 +101,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
          (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 80, 80)],
         False,
         None,
+        None,
         '0x01')
 
     assert mock_ipt_chain_exists.mock_calls == [
@@ -142,6 +143,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
                 (AF_INET, 32, True, u'1.2.3.66', 8080, 8080)],
             True,
             None,
+            None,
             '0x01')
     assert str(excinfo.value) == 'UDP not supported by nat method_name'
     assert mock_ipt_chain_exists.mock_calls == []
@@ -154,6 +156,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
         [(AF_INET, 24, False, u'1.2.3.0', 8000, 9000),
             (AF_INET, 32, True, u'1.2.3.66', 8080, 8080)],
         False,
+        None,
         None,
         '0x01')
     assert mock_ipt_chain_exists.mock_calls == [
@@ -182,7 +185,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
     mock_ipt_chain_exists.reset_mock()
     mock_ipt.reset_mock()
 
-    method.restore_firewall(1025, AF_INET, False, None)
+    method.restore_firewall(1025, AF_INET, False, None, None)
     assert mock_ipt_chain_exists.mock_calls == [
         call(AF_INET, 'nat', 'sshuttle-1025')
     ]
@@ -197,7 +200,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
     mock_ipt_chain_exists.reset_mock()
     mock_ipt.reset_mock()
 
-    method.restore_firewall(1025, AF_INET6, False, None)
+    method.restore_firewall(1025, AF_INET6, False, None,)
     assert mock_ipt_chain_exists.mock_calls == [
         call(AF_INET6, 'nat', 'sshuttle-1025')
     ]

--- a/tests/client/test_methods_nat.py
+++ b/tests/client/test_methods_nat.py
@@ -120,13 +120,13 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
              '--dest', u'2404:6800:4004:80c::33', '-p', 'udp',
              '--dport', '53', '--to-ports', '1026'),
         call(AF_INET6, 'nat', '-A', 'sshuttle-1024', '-j', 'RETURN',
-             '-m', 'addrtype', '--dst-type', 'LOCAL'),
-        call(AF_INET6, 'nat', '-A', 'sshuttle-1024', '-j', 'RETURN',
              '--dest', u'2404:6800:4004:80c::101f/128', '-p', 'tcp',
              '--dport', '80:80'),
         call(AF_INET6, 'nat', '-A', 'sshuttle-1024', '-j', 'REDIRECT',
              '--dest', u'2404:6800:4004:80c::/64', '-p', 'tcp',
-             '--to-ports', '1024')
+             '--to-ports', '1024'),
+        call(AF_INET6, 'nat', '-A', 'sshuttle-1024', '-j', 'RETURN',
+             '-m', 'addrtype', '--dst-type', 'LOCAL')
     ]
     mock_ipt_chain_exists.reset_mock()
     mock_ipt.reset_mock()
@@ -175,12 +175,12 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
              '--dest', u'1.2.3.33', '-p', 'udp',
              '--dport', '53', '--to-ports', '1027'),
         call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'RETURN',
-             '-m', 'addrtype', '--dst-type', 'LOCAL'),
-        call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'RETURN',
              '--dest', u'1.2.3.66/32', '-p', 'tcp', '--dport', '8080:8080'),
         call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'REDIRECT',
              '--dest', u'1.2.3.0/24', '-p', 'tcp', '--dport', '8000:9000',
-             '--to-ports', '1025')
+             '--to-ports', '1025'),
+        call(AF_INET, 'nat', '-A', 'sshuttle-1025', '-j', 'RETURN',
+             '-m', 'addrtype', '--dst-type', 'LOCAL'),
     ]
     mock_ipt_chain_exists.reset_mock()
     mock_ipt.reset_mock()
@@ -200,7 +200,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
     mock_ipt_chain_exists.reset_mock()
     mock_ipt.reset_mock()
 
-    method.restore_firewall(1025, AF_INET6, False, None,)
+    method.restore_firewall(1025, AF_INET6, False, None, None)
     assert mock_ipt_chain_exists.mock_calls == [
         call(AF_INET6, 'nat', 'sshuttle-1025')
     ]

--- a/tests/client/test_methods_pf.py
+++ b/tests/client/test_methods_pf.py
@@ -187,6 +187,7 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
             (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
         False,
         None,
+        None,
         '0x01')
     assert mock_ioctl.mock_calls == [
         call(mock_pf_get_dev(), 0xC4704433, ANY),
@@ -227,6 +228,7 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
                 (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
             True,
             None,
+            None,
             '0x01')
     assert str(excinfo.value) == 'UDP not supported by pf method_name'
     assert mock_pf_get_dev.mock_calls == []
@@ -240,6 +242,7 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
             (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
         False,
+        None,
         None,
         '0x01')
     assert mock_ioctl.mock_calls == [
@@ -270,7 +273,7 @@ def test_setup_firewall_darwin(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     mock_ioctl.reset_mock()
     mock_pfctl.reset_mock()
 
-    method.restore_firewall(1025, AF_INET, False, None)
+    method.restore_firewall(1025, AF_INET, False, None, None)
     assert mock_ioctl.mock_calls == []
     assert mock_pfctl.mock_calls == [
         call('-a sshuttle-1025 -F all'),
@@ -301,6 +304,7 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl,
         [(AF_INET6, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
             (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
         False,
+        None,
         None,
         '0x01')
 
@@ -335,6 +339,7 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl,
                 (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
             True,
             None,
+            None,
             '0x01')
     assert str(excinfo.value) == 'UDP not supported by pf method_name'
     assert mock_pf_get_dev.mock_calls == []
@@ -348,6 +353,7 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl,
         [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
             (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
         False,
+        None,
         None,
         '0x01')
     assert mock_ioctl.mock_calls == [
@@ -376,8 +382,8 @@ def test_setup_firewall_freebsd(mock_pf_get_dev, mock_ioctl, mock_pfctl,
     mock_ioctl.reset_mock()
     mock_pfctl.reset_mock()
 
-    method.restore_firewall(1025, AF_INET, False, None)
-    method.restore_firewall(1024, AF_INET6, False, None)
+    method.restore_firewall(1025, AF_INET, False, None, None)
+    method.restore_firewall(1024, AF_INET6, False, None, None)
     assert mock_ioctl.mock_calls == []
     assert mock_pfctl.mock_calls == [
         call('-a sshuttle-1025 -F all'),
@@ -407,6 +413,7 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         [(AF_INET6, 64, False, u'2404:6800:4004:80c::', 8000, 9000),
             (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
         False,
+        None,
         None,
         '0x01')
 
@@ -445,6 +452,7 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
                 (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
             True,
             None,
+            None,
             '0x01')
     assert str(excinfo.value) == 'UDP not supported by pf method_name'
     assert mock_pf_get_dev.mock_calls == []
@@ -458,6 +466,7 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
         [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
             (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
         False,
+        None,
         None,
         '0x01')
     assert mock_ioctl.mock_calls == [
@@ -484,8 +493,8 @@ def test_setup_firewall_openbsd(mock_pf_get_dev, mock_ioctl, mock_pfctl):
     mock_ioctl.reset_mock()
     mock_pfctl.reset_mock()
 
-    method.restore_firewall(1025, AF_INET, False, None)
-    method.restore_firewall(1024, AF_INET6, False, None)
+    method.restore_firewall(1025, AF_INET, False, None, None)
+    method.restore_firewall(1024, AF_INET6, False, None, None)
     assert mock_ioctl.mock_calls == []
     assert mock_pfctl.mock_calls == [
         call('-a sshuttle-1025 -F all'),

--- a/tests/client/test_methods_tproxy.py
+++ b/tests/client/test_methods_tproxy.py
@@ -98,6 +98,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
             (AF_INET6, 128, True, u'2404:6800:4004:80c::101f', 8080, 8080)],
         True,
         None,
+        None,
         '0x01')
     assert mock_ipt_chain_exists.mock_calls == [
         call(AF_INET6, 'mangle', 'sshuttle-m-1024'),
@@ -172,7 +173,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
     mock_ipt_chain_exists.reset_mock()
     mock_ipt.reset_mock()
 
-    method.restore_firewall(1025, AF_INET6, True, None)
+    method.restore_firewall(1025, AF_INET6, True, None, None)
     assert mock_ipt_chain_exists.mock_calls == [
         call(AF_INET6, 'mangle', 'sshuttle-m-1025'),
         call(AF_INET6, 'mangle', 'sshuttle-t-1025'),
@@ -200,6 +201,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
         [(AF_INET, 24, False, u'1.2.3.0', 0, 0),
             (AF_INET, 32, True, u'1.2.3.66', 80, 80)],
         True,
+        None,
         None,
         '0x01')
     assert mock_ipt_chain_exists.mock_calls == [
@@ -270,7 +272,7 @@ def test_setup_firewall(mock_ipt_chain_exists, mock_ipt):
     mock_ipt_chain_exists.reset_mock()
     mock_ipt.reset_mock()
 
-    method.restore_firewall(1025, AF_INET, True, None)
+    method.restore_firewall(1025, AF_INET, True, None, None)
     assert mock_ipt_chain_exists.mock_calls == [
         call(AF_INET, 'mangle', 'sshuttle-m-1025'),
         call(AF_INET, 'mangle', 'sshuttle-t-1025'),


### PR DESCRIPTION
## Add `--group` flag to filter network traffic emitted by the given group. 

This flag is useful especially when we want to run sshuttle on a docker container with `--net=host` but doesn't have the luxury to setup a new user to filter the traffic that we want to tunnel so that it wont affect the other container. 

## Allow user to tunnel localhost port in the remote host.

This is useful for users that uses `sshuttle` to tunnel their traffic to a jumpbox that has some sidecars listening on `127.0.0.1`  on that server. e.g. `sshuttle -r <remote> 0/0 127.0.0.1:8200/32`

Afterwards, users can reserve port `8200` so that the kernel won't allocate port on `8200` using [ip_local_reserved_ports](https://mjmwired.net/kernel/Documentation/networking/ip-sysctl.txt#916) in Linux.
