### PR TITLE
Add support for SSHUTTLE_ARGS environment variable

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -321,6 +321,18 @@ annotations. For example::
     192.168.63.0/24
 
 
+Environment Variable
+--------------------
+
+You can specify command line options with the `SSHUTTLE_ARGS` environment
+variable. If a given option is defined in both the environment variable and
+command line, the value on the command line will take precedence.
+
+For example::
+
+    SSHUTTLE_ARGS="-e 'ssh -v' --dns" sshuttle -r example.com 0/0
+
+
 Examples
 --------
 

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -1,5 +1,8 @@
+import os
 import re
+import shlex
 import socket
+import sys
 import sshuttle.helpers as helpers
 import sshuttle.client as client
 import sshuttle.firewall as firewall
@@ -11,7 +14,13 @@ from sshuttle.sudoers import sudoers
 
 
 def main():
-    opt = parser.parse_args()
+    if 'SSHUTTLE_ARGS' in os.environ:
+        env_args = shlex.split(os.environ['SSHUTTLE_ARGS'])
+    else:
+        env_args = []
+    args = [*env_args, *sys.argv[1:]]
+
+    opt = parser.parse_args(args)
 
     if opt.sudoers_no_modify:
         # sudoers() calls exit() when it completes


### PR DESCRIPTION
I use `sshuttle` in a few shell script aliases, for connecting to regular servers. Sometimes I want to debug the ssh connection and it's currently a painful process:
1. Update alias in `.bashrc`
2. Open a new shell
3. Re-run my `sshuttle` alias

With `SSHUTTLE_ARGS`, I can instead `export SSHUTTLE_ARGS='-e "ssh -v"'` and immediately re-run the alias. 🙌 

Thanks for a great utility!