### PR TITLE
Update FreeBSD Installation README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Obtaining sshuttle
       # ports
       cd /usr/ports/net/py-sshuttle && make install clean
       # pkg
-      pkg install py36-sshuttle
+      pkg install py39-sshuttle
 
 - OpenBSD::
 


### PR DESCRIPTION
The possible python versions in FreeBSD have changed for quite some time.
Packages with the `py36-` prefix are no longer included among the possible Python versions in FreeBSD.
https://cgit.freebsd.org/ports/blame/Mk/bsd.default-versions.mk
