### PR TITLE
Allow flake8 to determine the version of pyflakes

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 pytest==8.0.0
 pytest-cov==4.1.0
-flake8==6.1.0
-pyflakes==3.1.0
+flake8==7.0.0
 bump2version==1.0.1


### PR DESCRIPTION
Fixes #924 
Fixes #925 
* #924 
* #925 

`pyflakes` is a dependency of `flake8` so let's allow `flake8` to determine what version it needs.