### PR TITLE
Allows to switch to a network namespace on Linux

### DIFF
--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -11,6 +11,7 @@ import sshuttle.ssyslog as ssyslog
 from sshuttle.options import parser, parse_ipport
 from sshuttle.helpers import family_ip_tuple, log, Fatal
 from sshuttle.sudoers import sudoers
+from sshuttle.namespace import enter_namespace
 
 
 def main():
@@ -37,6 +38,13 @@ def main():
     helpers.verbose = opt.verbose
 
     try:
+        namespace = getattr(opt, 'namespace', None)
+        if namespace:
+            prefix = helpers.logprefix
+            helpers.logprefix = 'ns: '
+            enter_namespace(namespace)
+            helpers.logprefix = prefix
+
         if opt.firewall:
             if opt.subnets or opt.subnets_file:
                 parser.error('exactly zero arguments expected')

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -38,6 +38,8 @@ def main():
     helpers.verbose = opt.verbose
 
     try:
+        # Since namespace and namespace-pid options are only available
+        # in linux, we must check if it exists with getattr
         namespace = getattr(opt, 'namespace', None)
         namespace_pid = getattr(opt, 'namespace_pid', None)
         if namespace or namespace_pid:

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -39,10 +39,11 @@ def main():
 
     try:
         namespace = getattr(opt, 'namespace', None)
-        if namespace:
+        namespace_pid = getattr(opt, 'namespace_pid', None)
+        if namespace or namespace_pid:
             prefix = helpers.logprefix
             helpers.logprefix = 'ns: '
-            enter_namespace(namespace)
+            enter_namespace(namespace, namespace_pid)
             helpers.logprefix = prefix
 
         if opt.firewall:

--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -20,7 +20,7 @@ def ipt_chain_exists(family, table, name):
     argv = [cmd, '-w', '-t', table, '-nL']
     try:
         output = ssubprocess.check_output(argv, env=get_env())
-        for line in output.decode('ASCII').split('\n'):
+        for line in output.decode('ASCII', errors='replace').split('\n'):
             if line.startswith('Chain %s ' % name):
                 return True
     except ssubprocess.CalledProcessError as e:

--- a/sshuttle/namespace.py
+++ b/sshuttle/namespace.py
@@ -14,13 +14,13 @@ def enter_namespace(namespace, namespace_pid):
         namespace_dir = f'{NETNS_RUN_DIR}/{namespace}'
     else:
         namespace_dir = f'/proc/{namespace_pid}/ns/net'
-    
+
     if not os.path.exists(namespace_dir):
         raise Fatal('The namespace %r does not exists.' % namespace_dir)
 
     debug2('loading libc')
     libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
-    
+
     default_errcheck = libc.setns.errcheck
 
     def errcheck(ret, *args):
@@ -29,8 +29,8 @@ def enter_namespace(namespace, namespace_pid):
             raise Fatal(e, os.strerror(e))
         if default_errcheck:
             return default_errcheck(ret, *args)
-    
-    libc.setns.errcheck = errcheck # type: ignore
+
+    libc.setns.errcheck = errcheck  # type: ignore
 
     debug1('Entering namespace %r' % namespace_dir)
 

--- a/sshuttle/namespace.py
+++ b/sshuttle/namespace.py
@@ -9,12 +9,15 @@ CLONE_NEWNET = 0x40000000
 NETNS_RUN_DIR = "/var/run/netns"
 
 
-def enter_namespace(namespace):
-    namespace_dir = f'{NETNS_RUN_DIR}/{namespace}'
-
+def enter_namespace(namespace, namespace_pid):
+    if namespace:
+        namespace_dir = f'{NETNS_RUN_DIR}/{namespace}'
+    else:
+        namespace_dir = f'/proc/{namespace_pid}/ns/net'
+    
     if not os.path.exists(namespace_dir):
         raise Fatal('The namespace %r does not exists.' % namespace_dir)
-    
+
     debug2('loading libc')
     libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
     
@@ -29,8 +32,9 @@ def enter_namespace(namespace):
     
     libc.setns.errcheck = errcheck # type: ignore
 
-    debug1('Entering namespace %r' % namespace)
+    debug1('Entering namespace %r' % namespace_dir)
+
     with open(namespace_dir) as fd:
         libc.setns(fd.fileno(), CLONE_NEWNET)
 
-    debug1('Namespace %r successfully set' % namespace)
+    debug1('Namespace %r successfully set' % namespace_dir)

--- a/sshuttle/namespace.py
+++ b/sshuttle/namespace.py
@@ -1,0 +1,36 @@
+import os
+import ctypes
+import ctypes.util
+
+from sshuttle.helpers import Fatal, debug1, debug2
+
+
+CLONE_NEWNET = 0x40000000
+NETNS_RUN_DIR = "/var/run/netns"
+
+
+def enter_namespace(namespace):
+    namespace_dir = f'{NETNS_RUN_DIR}/{namespace}'
+
+    if not os.path.exists(namespace_dir):
+        raise Fatal('The namespace %r does not exists.' % namespace_dir)
+    
+    debug2('loading libc')
+    libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+    
+    default_errcheck = libc.setns.errcheck
+
+    def errcheck(ret, *args):
+        if ret == -1:
+            e = ctypes.get_errno()
+            raise Fatal(e, os.strerror(e))
+        if default_errcheck:
+            return default_errcheck(ret, *args)
+    
+    libc.setns.errcheck = errcheck # type: ignore
+
+    debug1('Entering namespace %r' % namespace)
+    with open(namespace_dir) as fd:
+        libc.setns(fd.fileno(), CLONE_NEWNET)
+
+    debug1('Namespace %r successfully set' % namespace)

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -471,12 +471,15 @@ parser.add_argument(
 )
 
 if sys.platform == 'linux':
-    parser.add_argument(
+    net_ns_group = parser.add_mutually_exclusive_group(
+        required=False)
+
+    net_ns_group.add_argument(
         '--namespace',
         type=parse_namespace,
         help="Run inside of a net namespace with the given name."
     )
-    parser.add_argument(
+    net_ns_group.add_argument(
         '--namespace-pid',
         type=int,
         help="""

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -137,6 +137,15 @@ def parse_list(lst):
     return re.split(r'[\s,]+', lst.strip()) if lst else []
 
 
+def parse_namespace(namespace):
+    try:
+        assert re.fullmatch(
+            r'(@?[a-z_A-Z]\w+(?:\.@?[a-z_A-Z]\w+)*)', namespace)
+        return namespace
+    except AssertionError:
+        raise Fatal("%r is not a valid namespace name." % namespace)
+
+
 class Concat(Action):
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         if nargs is not None:
@@ -460,3 +469,10 @@ parser.add_argument(
     hexadecimal (default '0x01')
     """
 )
+
+if sys.platform == 'linux':
+    parser.add_argument(
+        '--namespace',
+        type=parse_namespace,
+        help="Run it inside of a namespace."
+    )

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -474,5 +474,12 @@ if sys.platform == 'linux':
     parser.add_argument(
         '--namespace',
         type=parse_namespace,
-        help="Run it inside of a namespace."
+        help="Run inside of a net namespace with the given name."
+    )
+    parser.add_argument(
+        '--namespace-pid',
+        type=int,
+        help="""
+        Run inside the net namespace used by the process with
+        the given pid."""
     )

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -189,7 +189,7 @@ def test_parse_namespace():
         '@my.long_namespace.with.multiple.dots',
         'my.Namespace.With.Mixed.Case',
     ]
-    
+
     for namespace in valid_namespaces:
         assert sshuttle.options.parse_namespace(namespace) == namespace
 

--- a/tests/client/test_options.py
+++ b/tests/client/test_options.py
@@ -176,3 +176,33 @@ def test_parse_subnetport_host_with_port(mock_getaddrinfo):
             (socket.AF_INET6, '2404:6800:4004:821::2001', 128, 80, 90),
             (socket.AF_INET, '142.251.42.129', 32, 80, 90),
         ])
+
+
+def test_parse_namespace():
+    valid_namespaces = [
+        'my_namespace',
+        'my.namespace',
+        'my_namespace_with_underscore',
+        'MyNamespace',
+        '@my_namespace',
+        'my.long_namespace.with.multiple.dots',
+        '@my.long_namespace.with.multiple.dots',
+        'my.Namespace.With.Mixed.Case',
+    ]
+    
+    for namespace in valid_namespaces:
+        assert sshuttle.options.parse_namespace(namespace) == namespace
+
+    invalid_namespaces = [
+        '',
+        '123namespace',
+        'my-namespace',
+        'my_namespace!',
+        '.my_namespace',
+        'my_namespace.',
+        'my..namespace',
+    ]
+
+    for namespace in invalid_namespaces:
+        with pytest.raises(Fatal, match="'.*' is not a valid namespace name."):
+            sshuttle.options.parse_namespace(namespace)


### PR DESCRIPTION
Adds two convenient ways of spawning sshuttle instances inside of a network namespace.

**Usage**: 

`sshuttle --namespace foo -r joe@example.com:22 10.11.0.0/24`
The result is the same as calling `ip netns exec $NAMESPACE sshuttle foo -r joe@example.com:22 10.11.0.0/24`, but it's a little bit more convenient.

`sshuttle --namespace-pid 647 -r joe@example.com:22 10.11.0.0/24`
Switch to the process's network namespace.
