### PR TITLE
fix: Correct PYTHONPATH for --sudoers-no-modify

### DIFF
--- a/sshuttle/sudoers.py
+++ b/sshuttle/sudoers.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import getpass
+from pathlib import Path
 from uuid import uuid4
 
 
@@ -10,7 +11,7 @@ def build_config(user_name):
     argv0 = os.path.abspath(sys.argv[0])
     is_python_script = argv0.endswith('.py')
     executable = f"{sys.executable} {argv0}" if is_python_script else argv0
-    dist_packages = os.path.dirname(os.path.abspath(__file__))
+    dist_packages = str(Path(os.path.abspath(__file__)).parent.parent)
     cmd_alias = f"SSHUTTLE{uuid4().hex[-3:].upper()}"
 
     template = f"""


### PR DESCRIPTION
Relates to [issue 1041](https://github.com/sshuttle/sshuttle/issues/1041); the previous fix ([934fac9d](https://github.com/sshuttle/sshuttle/commit/934fac9d6c0f86223e3e7120148d346d9b20c9d0)) looks to have dropped removal of `/sshuttle` from the end of the dist_packages variable, leading to the PYTHONPATH pointing to the sshuttle module directly, instead of parent `site-packages`.

This change returns the previous functionality (using pathlib instead for clarity) of removing two path sections from the end, instead of just one in the above fix. In my testing, this has resolved the issue with --sudoers-no-modify output.