### PR TITLE
fixed clone installation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,7 +37,7 @@ Installation
 
       git clone https://github.com/sshuttle/sshuttle.git
       cd sshuttle
-      sudo ./setup.py install
+      sudo pip install .
 
 - FreeBSD::
 


### PR DESCRIPTION
Hi, this is a minor fix for the documentation

in the installation guide, in the clone part you have the 

```
git clone https://github.com/sshuttle/sshuttle.git
cd sshuttle
sudo ./setup.py install
```

but the code don't have the `setup.py` and this would gives error, so the correct way of doing it would be using the `pip install .` instead.

and I tried to fix it in the PR.

best regards