### PR TITLE
Bug fixed: fport and lport are in the wrong places.

### DIFF
--- a/sshuttle/methods/windivert.py
+++ b/sshuttle/methods/windivert.py
@@ -334,8 +334,8 @@ class Method(BaseMethod):
         subnet_addresses = []
         for (_, mask, exclude, network_addr, fport, lport) in subnets:
             if fport and lport:
-                if lport > fport:
-                    raise Fatal("lport must be less than or equal to fport")
+                if lport < fport:
+                    raise Fatal("fport must be less than or equal to lport")
                 ports = (fport, lport)
             else:
                 ports = None

--- a/sshuttle/methods/windivert.py
+++ b/sshuttle/methods/windivert.py
@@ -332,11 +332,11 @@ class Method(BaseMethod):
                             f"No address found for {family.name} in {local_addresses}")
         debug2(f"Found non loopback address to connect to proxy: {proxy_ip}")
         subnet_addresses = []
-        for (_, mask, exclude, network_addr, fport, lport) in subnets:
+        for (_, mask, exclude, network_addr, lport, fport) in subnets:
             if fport and lport:
                 if lport > fport:
                     raise Fatal("lport must be less than or equal to fport")
-                ports = (fport, lport)
+                ports = (lport, fport)
             else:
                 ports = None
             subnet_addresses.append((ip_network(f"{network_addr}/{mask}"), ports, exclude))


### PR DESCRIPTION
On Windows 11 it was impossible to set a port range like 1.2.3.0/24:8000-9000