### PR TITLE
feat: auto-exclude remote IP

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -352,15 +352,14 @@ Use the following command to route all IPv4 TCP traffic through remote
 (-r) host example.com (and possibly other traffic too, depending on
 the selected --method). The 0/0 subnet, short for 0.0.0.0/0, matches
 all IPv4 addresses. The ::/0 subnet, matching all IPv6 addresses could
-be added to the example. We also exclude (-x) example.com:22 so that
-we can establish ssh connections from our local machine to the remote
-host without them being routed through sshuttle. Excluding the remote
-host may be necessary on some machines for sshuttle to work properly.
-Press Ctrl+C to exit. To also route DNS queries through sshuttle, try
-adding --dns. Add or remove -v options to see more or less
-information::
+be added to the example. The SSH connection endpoint is automatically
+excluded from forwarding. When `ProxyCommand` is configured,
+automatic exclusion is skipped; use :option:`-x` to exclude the
+required address manually. Press Ctrl+C to exit. To also route DNS
+queries through sshuttle, try adding --dns. Add or remove -v options
+to see more or less information::
 
-    $ sshuttle -r example.com -x example.com:22 0/0
+    $ sshuttle -r example.com 0/0
 
     Starting sshuttle proxy (version ...).
     [local sudo] Password:
@@ -376,8 +375,8 @@ information::
     c : Subnets to forward through remote host (type, IP, cidr mask width, startPort, endPort):
     c :   (<AddressFamily.AF_INET: 2>, '0.0.0.0', 0, 0, 0)
     c : Subnets to exclude from forwarding:
-    c :   (<AddressFamily.AF_INET: 2>, '...', 32, 22, 22)
     c :   (<AddressFamily.AF_INET: 2>, '127.0.0.1', 32, 0, 0)
+    c :   (<AddressFamily.AF_INET: 2>, '...', 32, 0, 0)
     c : TCP redirector listening on ('127.0.0.1', 12299).
     c : Starting client with Python version 3.9.5
     c : Connecting to server...
@@ -400,7 +399,7 @@ information::
 Connect to a remote server, with automatic hostname
 and subnet guessing::
 
-    $ sshuttle -vNHr example.com -x example.com:22
+    $ sshuttle -vNHr example.com
     Starting sshuttle proxy (version ...).
     [local sudo] Password:
     fw: Starting firewall with Python version 3.9.5
@@ -415,8 +414,8 @@ and subnet guessing::
     c : Subnets to forward through remote host (type, IP, cidr mask width, startPort, endPort):
     c : NOTE: Additional subnets to forward may be added below by --auto-nets.
     c : Subnets to exclude from forwarding:
-    c :   (<AddressFamily.AF_INET: 2>, '...', 32, 22, 22)
     c :   (<AddressFamily.AF_INET: 2>, '127.0.0.1', 32, 0, 0)
+    c :   (<AddressFamily.AF_INET: 2>, '...', 32, 0, 0)
     c : TCP redirector listening on ('127.0.0.1', 12300).
     c : Starting client with Python version 3.9.5
     c : Connecting to server...

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,10 +11,9 @@ Forward all traffic::
     sshuttle -r username@sshserver 0.0.0.0/0
 
 - Use the :option:`sshuttle -r` parameter to specify a remote server.
-  On some systems, you may also need to use the :option:`sshuttle -x`
-  parameter to exclude sshserver or sshserver:22 so that your local
-  machine can communicate directly to sshserver without it being
-  redirected by sshuttle.
+  The SSH connection endpoint is automatically excluded from forwarding.
+  When `ProxyCommand` is configured, automatic exclusion is skipped;
+  use :option:`sshuttle -x` to exclude the required address manually.
 
 - By default sshuttle will automatically choose a method to use. Override with
   the :option:`sshuttle --method` parameter.

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -17,7 +17,6 @@ from sshuttle.ssnet import SockWrapper, Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import log, debug1, debug2, debug3, Fatal, islocal, \
     resolvconf_nameservers, which, is_admin_user, RWPair
 from sshuttle.methods import get_method, Features
-from sshuttle.options import parse_ipport
 from sshuttle import __version__
 try:
     from pwd import getpwnam
@@ -991,14 +990,17 @@ def main(listenip_v6, listenip_v4,
         subnets_exclude.append((socket.AF_INET6, listenip_v6[0], 128, 0, 0))
 
     # Exclude remote server IP
-    _, _, _, host = ssh.parse_hostport(remotename)
+    host = ssh.parse_hostname(remotename)
     if host:
         try:
-            family, remote_ip, _ = parse_ipport(host)
-            if not any(remote_ip == sex[1] for sex in subnets_exclude):
-                subnets_exclude.append((family, remote_ip, 32 if family == socket.AF_INET else 128, 0, 0))
-        except Exception:
-            pass
+            addrinfo = socket.getaddrinfo(host, None, 0, socket.SOCK_STREAM)
+            if addrinfo:
+                family = addrinfo[0][0]
+                remote_ip = addrinfo[0][4][0]
+                if not any(remote_ip == sex[1] for sex in subnets_exclude):
+                    subnets_exclude.append((family, remote_ip, 32 if family == socket.AF_INET else 128, 0, 0))
+        except Exception as e:
+            raise Fatal(f"Failed to exclude remote IP: {e}")
     # We don't print the IP+port of where we are listening here
     # because we do that below when we have identified the ports to
     # listen on.

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -992,10 +992,10 @@ def main(listenip_v6, listenip_v4,
     # Exclude remote server IP
     host, proxy_host = ssh.parse_hostname(remotename)
     hosts_to_exclude = []
-    if host:
-        hosts_to_exclude.append(host)
     if proxy_host:
         hosts_to_exclude.append(proxy_host)
+    elif host:
+        hosts_to_exclude.append(host)
     for host in hosts_to_exclude:
         try:
             addrinfo = socket.getaddrinfo(host, None, 0, socket.SOCK_STREAM)

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -1004,12 +1004,13 @@ def main(listenip_v6, listenip_v4,
     for host in hosts_to_exclude:
         try:
             addrinfo = socket.getaddrinfo(host, None, 0, socket.SOCK_STREAM)
-            if addrinfo:
-                family = addrinfo[0][0]
-                remote_ip = addrinfo[0][4][0]
+            for family, _, _, _, sockaddr in addrinfo:
+                remote_ip = sockaddr[0]
+
                 # Strip IPv6 scope suffix, e.g. fe80::1%eth0
                 if family == socket.AF_INET6:
                     remote_ip = remote_ip.split('%', 1)[0]
+
                 if not any(remote_ip == sex[1] for sex in subnets_exclude):
                     subnets_exclude.append((family, remote_ip, 32 if family == socket.AF_INET else 128, 0, 0))
         except Exception as e:

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -990,8 +990,13 @@ def main(listenip_v6, listenip_v4,
         subnets_exclude.append((socket.AF_INET6, listenip_v6[0], 128, 0, 0))
 
     # Exclude remote server IP
-    host = ssh.parse_hostname(remotename)
+    host, proxy_host = ssh.parse_hostname(remotename)
+    hosts_to_exclude = []
     if host:
+        hosts_to_exclude.append(host)
+    if proxy_host:
+        hosts_to_exclude.append(proxy_host)
+    for host in hosts_to_exclude:
         try:
             addrinfo = socket.getaddrinfo(host, None, 0, socket.SOCK_STREAM)
             if addrinfo:

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -997,9 +997,8 @@ def main(listenip_v6, listenip_v4,
             family, remote_ip, _ = parse_ipport(host)
             if not any(remote_ip == sex[1] for sex in subnets_exclude):
                 subnets_exclude.append((family, remote_ip, 32 if family == socket.AF_INET else 128, 0, 0))
-        except:
+        except Exception:
             pass
-    
     # We don't print the IP+port of where we are listening here
     # because we do that below when we have identified the ports to
     # listen on.

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -990,9 +990,14 @@ def main(listenip_v6, listenip_v4,
         subnets_exclude.append((socket.AF_INET6, listenip_v6[0], 128, 0, 0))
 
     # Exclude remote server IP
-    host, proxy_host = ssh.parse_hostname(remotename)
+    host, proxy_host, proxy_command = ssh.parse_hostname(remotename)
     hosts_to_exclude = []
-    if proxy_host:
+    if proxy_command:
+        debug1(
+            "Warning: ProxyCommand is configured; skipping automatic remote IP exclusion. "
+            "Use -x explicitly if required.\n"
+        )
+    elif proxy_host:
         hosts_to_exclude.append(proxy_host)
     elif host:
         hosts_to_exclude.append(host)
@@ -1005,7 +1010,7 @@ def main(listenip_v6, listenip_v4,
                 if not any(remote_ip == sex[1] for sex in subnets_exclude):
                     subnets_exclude.append((family, remote_ip, 32 if family == socket.AF_INET else 128, 0, 0))
         except Exception as e:
-            debug1(f"Failed to exclude remote IP: {e}")
+            debug1(f"Failed to exclude remote IP: {e}\n")
     # We don't print the IP+port of where we are listening here
     # because we do that below when we have identified the ports to
     # listen on.

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -1005,7 +1005,7 @@ def main(listenip_v6, listenip_v4,
                 if not any(remote_ip == sex[1] for sex in subnets_exclude):
                     subnets_exclude.append((family, remote_ip, 32 if family == socket.AF_INET else 128, 0, 0))
         except Exception as e:
-            raise Fatal(f"Failed to exclude remote IP: {e}")
+            debug1(f"Failed to exclude remote IP: {e}")
     # We don't print the IP+port of where we are listening here
     # because we do that below when we have identified the ports to
     # listen on.

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -1007,6 +1007,9 @@ def main(listenip_v6, listenip_v4,
             if addrinfo:
                 family = addrinfo[0][0]
                 remote_ip = addrinfo[0][4][0]
+                # Strip IPv6 scope suffix, e.g. fe80::1%eth0
+                if family == socket.AF_INET6:
+                    remote_ip = remote_ip.split('%', 1)[0]
                 if not any(remote_ip == sex[1] for sex in subnets_exclude):
                     subnets_exclude.append((family, remote_ip, 32 if family == socket.AF_INET else 128, 0, 0))
         except Exception as e:

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -17,6 +17,7 @@ from sshuttle.ssnet import SockWrapper, Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import log, debug1, debug2, debug3, Fatal, islocal, \
     resolvconf_nameservers, which, is_admin_user, RWPair
 from sshuttle.methods import get_method, Features
+from sshuttle.options import parse_ipport
 from sshuttle import __version__
 try:
     from pwd import getpwnam
@@ -989,6 +990,16 @@ def main(listenip_v6, listenip_v4,
             not any(listenip_v6[0] == sex[1] for sex in subnets_v6):
         subnets_exclude.append((socket.AF_INET6, listenip_v6[0], 128, 0, 0))
 
+    # Exclude remote server IP
+    _, _, _, host = ssh.parse_hostport(remotename)
+    if host:
+        try:
+            family, remote_ip, _ = parse_ipport(host)
+            if not any(remote_ip == sex[1] for sex in subnets_exclude):
+                subnets_exclude.append((family, remote_ip, 32 if family == socket.AF_INET else 128, 0, 0))
+        except:
+            pass
+    
     # We don't print the IP+port of where we are listening here
     # because we do that below when we have identified the ports to
     # listen on.

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -34,14 +34,15 @@ def parse_hostname(remotename):
     """
     Parse and resolve SSH remote hostname.
     Uses 'ssh -G' to query the effective SSH configuration.
-    Returns tuple of (remote_host, proxy_host) or (None, None) if resolution fails.
+    Returns tuple of (remote_host, proxy_host, proxy_command).
     """
     _, _, _, host = parse_hostport(remotename)
     if not host:
-        return None, None
+        return None, None, None
 
     remote_host = None
     proxy_host = None
+    proxy_command = None
 
     try:
         result = ssubprocess.run(
@@ -51,15 +52,19 @@ def parse_hostname(remotename):
             for line in result.stdout.split('\n'):
                 if line.startswith('hostname '):
                     remote_host = line.split(' ', 1)[1].strip()
-                if line.startswith('proxyjump '):
+                elif line.startswith('proxyjump '):
                     proxy_raw = line.split(' ', 1)[1].strip()
                     # Remove brackets
                     proxy_raw = proxy_raw.replace('[', '').replace(']', '')
                     _, _, _, proxy_host = parse_hostport(proxy_raw)
+                elif line.startswith('proxycommand '):
+                    command = line.split(' ', 1)[1].strip()
+                    if command.lower() != 'none':
+                        proxy_command = command
     except Exception:
         pass
 
-    return remote_host or host, proxy_host
+    return remote_host or host, proxy_host, proxy_command
 
 
 def parse_hostport(rhostport):

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -30,6 +30,30 @@ def empackage(z, name, data=None):
     return b'%s\n%d\n%s' % (name.encode("ASCII"), len(content), content)
 
 
+def parse_hostname(remotename):
+    """
+    Parse and resolve SSH remote hostname, including SSH config aliases.
+    Uses 'ssh -G' to query the effective SSH configuration.
+    Returns the resolved hostname, or the original if resolution fails.
+    """
+    _, _, _, host = parse_hostport(remotename)
+    if not host:
+        return None
+
+    try:
+        result = ssubprocess.run(
+            ['ssh', '-G', host],
+            capture_output=True, text=True, timeout=2)
+        if result.returncode == 0:
+            for line in result.stdout.split('\n'):
+                if line.startswith('hostname '):
+                    return line.split(' ', 1)[1].strip()
+    except Exception:
+        pass
+
+    return host
+
+
 def parse_hostport(rhostport):
     """
     parses the given rhostport variable, looking like this:

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -32,13 +32,16 @@ def empackage(z, name, data=None):
 
 def parse_hostname(remotename):
     """
-    Parse and resolve SSH remote hostname, including SSH config aliases.
+    Parse and resolve SSH remote hostname.
     Uses 'ssh -G' to query the effective SSH configuration.
-    Returns the resolved hostname, or the original if resolution fails.
+    Returns tuple of (remote_host, proxy_host) or (None, None) if resolution fails.
     """
     _, _, _, host = parse_hostport(remotename)
     if not host:
-        return None
+        return None, None
+
+    remote_host = None
+    proxy_host = None
 
     try:
         result = ssubprocess.run(
@@ -47,11 +50,16 @@ def parse_hostname(remotename):
         if result.returncode == 0:
             for line in result.stdout.split('\n'):
                 if line.startswith('hostname '):
-                    return line.split(' ', 1)[1].strip()
+                    remote_host = line.split(' ', 1)[1].strip()
+                if line.startswith('proxyjump '):
+                    proxy_raw = line.split(' ', 1)[1].strip()
+                    # Remove brackets
+                    proxy_raw = proxy_raw.replace('[', '').replace(']', '')
+                    _, _, _, proxy_host = parse_hostport(proxy_raw)
     except Exception:
         pass
 
-    return host
+    return remote_host or host, proxy_host
 
 
 def parse_hostport(rhostport):


### PR DESCRIPTION
Auto-exclude the remote IP from the routing table.
No longer requires defining the -x <remote_ip> flag.

```
./run -vr root@<remote_ip>:2200 0/0

Starting sshuttle proxy (version 1.3.2).
c : Starting firewall manager with command: ['/usr/bin/python3', '/root/sshuttle/sshuttle/__main__.py', '-v', '--method', 'auto', '--firewall']
fw: Starting firewall with Python version 3.14.4
fw: ready method name nat.
c : Using default IPv4 listen address 127.0.0.1
c : IPv6 enabled: Using default IPv6 listen address ::1
c : Method: nat
c : IPv4: on
c : IPv6: on
c : UDP : off (not available with nat method)
c : DNS : off (available)
c : User: off (available)
c : Subnets to forward through remote host (type, IP, cidr mask width, startPort, endPort):
c :   (<AddressFamily.AF_INET: 2>, '0.0.0.0', 0, 0, 0)
c : Subnets to exclude from forwarding:
c :   (<AddressFamily.AF_INET: 2>, '127.0.0.1', 32, 0, 0)
c :   (<AddressFamily.AF_INET6: 10>, '::1', 128, 0, 0)
c :   (<AddressFamily.AF_INET: 2>, '<remote_ip>', 32, 0, 0)
c : TCP redirector listening on ('::1', 12300, 0, 0).
c : TCP redirector listening on ('127.0.0.1', 12300).
c : Starting client with Python version 3.14.4
c : Connecting to server...
root@<remote_ip>'s password:
 s: Running server on remote host with /usr/bin/python3 (version 3.14.4)
 s: latency control setting = True
 s: auto-nets:False
c : Connected to server.
fw: setting up.
fw: ip6tables -w -t nat -N sshuttle-12300
fw: ip6tables -w -t nat -F sshuttle-12300
fw: ip6tables -w -t nat -I OUTPUT 1 -j sshuttle-12300
fw: ip6tables -w -t nat -I PREROUTING 1 -j sshuttle-12300
fw: ip6tables -w -t nat -A sshuttle-12300 -j RETURN --dest ::1/128 -p tcp
fw: ip6tables -w -t nat -A sshuttle-12300 -j RETURN -m addrtype --dst-type LOCAL
fw: iptables -w -t nat -N sshuttle-12300
fw: iptables -w -t nat -F sshuttle-12300
fw: iptables -w -t nat -I OUTPUT 1 -j sshuttle-12300
fw: iptables -w -t nat -I PREROUTING 1 -j sshuttle-12300
fw: iptables -w -t nat -A sshuttle-12300 -j RETURN --dest 127.0.0.1/32 -p tcp
fw: iptables -w -t nat -A sshuttle-12300 -j RETURN --dest <remote_ip>/32 -p tcp
fw: iptables -w -t nat -A sshuttle-12300 -j REDIRECT --dest 0.0.0.0/0 -p tcp --to-ports 12300
fw: iptables -w -t nat -A sshuttle-12300 -j RETURN -m addrtype --dst-type LOCAL
```