### PR TITLE
Close finished sockets on helper threads

### DIFF
--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -12,7 +12,8 @@ import sshuttle.ssnet as ssnet
 import sshuttle.helpers as helpers
 import sshuttle.hostwatch as hostwatch
 import subprocess as ssubprocess
-from sshuttle.ssnet import Handler, Proxy, Mux, MuxWrapper
+from sshuttle.ssnet import Handler, Proxy, Mux, MuxWrapper, \
+    close_later
 from sshuttle.helpers import b, log, debug1, debug2, debug3, Fatal, \
     get_random_nameserver, which, get_env, SocketRWShim
 
@@ -168,6 +169,12 @@ class Hostwatch:
 
 class DnsProxy(Handler):
 
+    def dispose(self):
+        # self.peers holds every socket we made, including ones whose send()
+        # failed and so never reached self.socks.
+        for sock in self.peers:
+            close_later(sock)
+
     def __init__(self, mux, chan, request, to_nameserver):
         Handler.__init__(self, [])
         self.timeout = time.time() + 30
@@ -254,6 +261,9 @@ class DnsProxy(Handler):
 
 
 class UdpProxy(Handler):
+
+    def dispose(self):
+        close_later(self.sock)
 
     def __init__(self, mux, chan, family):
         sock = socket.socket(family, socket.SOCK_DGRAM)

--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -26,8 +26,17 @@ MAX_CHANNEL = 65535
 # all queued behind the same close().
 #
 # Closing on helper threads keeps the event loop responsive. The threads only
-# ever sleep in close(), so the pool size just sets how fast a backlog drains.
+# ever sleep in close(), so the pool size just sets how fast a backlog drains:
+# CLOSERS/latency closes per second.
 CLOSERS = 4
+
+# Cap on the number of finished sockets waiting to be closed. Each one holds
+# its fd open until a helper gets to it, so an unbounded queue trades a stalled
+# event loop for fd exhaustion under sustained churn that outruns the closers.
+# Past this many, close_later() closes inline instead: at that point the
+# backlog is pathological and stalling is the lesser failure.
+MAX_CLOSE_BACKLOG = 512
+
 _close_q = None
 
 
@@ -39,17 +48,16 @@ def close_later(sock):
     the fd) is queued, which keeps it referenced until the helper closes it,
     so the interpreter cannot close the same fd twice.
 
-    The queue is unbounded. If closes run slower than connection churn, the
-    finished sockets pile up in it and hold their fds open until a helper
-    gets to them, so a long burst can push the process toward its fd limit.
-    Bounding the queue would just move the stall back onto the event loop,
-    which is the thing this is here to avoid.
+    If closes run slower than connection churn, the finished sockets pile up
+    in the queue and hold their fds open until a helper gets to them. The
+    queue is capped at MAX_CLOSE_BACKLOG for that reason; beyond it we close
+    inline and take the stall, rather than run the process out of fds.
     """
     global _close_q
     if sock is None:
         return
     if _close_q is None:
-        _close_q = queue.SimpleQueue()
+        _close_q = queue.Queue(maxsize=MAX_CLOSE_BACKLOG)
 
         def closer():
             while True:
@@ -62,7 +70,14 @@ def close_later(sock):
         for i in range(CLOSERS):
             threading.Thread(target=closer, name='sshuttle-closer-%d' % i,
                              daemon=True).start()
-    _close_q.put(sock)
+    try:
+        _close_q.put_nowait(sock)
+    except queue.Full:
+        debug1('close backlog full (%d); closing inline' % MAX_CLOSE_BACKLOG)
+        try:
+            sock.close()
+        except Exception as e:
+            debug1('error closing %r: %s' % (sock, e))
 
 
 LATENCY_BUFFER_SIZE = 32768

--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -1,6 +1,8 @@
 import sys
 import struct
+import queue
 import socket
+import threading
 import errno
 import select
 import os
@@ -8,6 +10,61 @@ import os
 from sshuttle.helpers import b, log, debug1, debug2, debug3, Fatal, set_non_blocking_io
 
 MAX_CHANNEL = 65535
+
+# Number of helper threads used to close finished sockets.
+#
+# close() on a socket is normally instant, but it can block in the kernel for
+# many seconds on hosts where a socket-filter network extension inspects flow
+# teardown (observed on macOS with third-party endpoint-security and VPN
+# clients installed: individual close() calls blocking 9-12 seconds with the
+# process at 0% CPU).
+#
+# sshuttle's event loop is single threaded, so one blocking close() stalls
+# every other connection in the tunnel, not just the one being closed. The
+# symptom is severe: requests that normally take 0.2s intermittently take
+# 5-15s, and unrelated connections stall together in bursts because they are
+# all queued behind the same close().
+#
+# Closing on helper threads keeps the event loop responsive. The threads only
+# ever sleep in close(), so the pool size just sets how fast a backlog drains.
+CLOSERS = 4
+_close_q = None
+
+
+def close_later(sock):
+    """Close a finished socket without blocking the event loop.
+
+    Only call this for sockets whose handler has already been dropped from
+    the poll set, so nothing will touch them again. The socket object (not
+    the fd) is queued, which keeps it referenced until the helper closes it,
+    so the interpreter cannot close the same fd twice.
+
+    The queue is unbounded. If closes run slower than connection churn, the
+    finished sockets pile up in it and hold their fds open until a helper
+    gets to them, so a long burst can push the process toward its fd limit.
+    Bounding the queue would just move the stall back onto the event loop,
+    which is the thing this is here to avoid.
+    """
+    global _close_q
+    if sock is None:
+        return
+    if _close_q is None:
+        _close_q = queue.SimpleQueue()
+
+        def closer():
+            while True:
+                sock = _close_q.get()
+                try:
+                    sock.close()
+                except Exception as e:
+                    debug1('error closing %r: %s' % (sock, e))
+
+        for i in range(CLOSERS):
+            threading.Thread(target=closer, name='sshuttle-closer-%d' % i,
+                             daemon=True).start()
+    _close_q.put(sock)
+
+
 LATENCY_BUFFER_SIZE = 32768
 
 SHUT_RD = 0
@@ -109,6 +166,16 @@ _swcount = 0
 
 
 class SockWrapper:
+
+    def dispose(self):
+        """Hand our sockets to the closer pool.
+
+        Only called once the wrapper's handler has been dropped from the
+        poll set, so nothing will touch them again.
+        """
+        close_later(self.rsock)
+        if self.wsock is not self.rsock:
+            close_later(self.wsock)
 
     def __init__(self, rsock, wsock, connect_to=None, peername=None):
         global _swcount
@@ -276,6 +343,9 @@ class SockWrapper:
 
 class Handler:
 
+    def dispose(self):
+        pass
+
     def __init__(self, socks=None, callback=None):
         self.ok = True
         self.socks = socks or []
@@ -298,6 +368,10 @@ class Handler:
 
 
 class Proxy(Handler):
+
+    def dispose(self):
+        self.wrap1.dispose()
+        self.wrap2.dispose()
 
     def __init__(self, wrap1, wrap2):
         Handler.__init__(self, [wrap1.rsock, wrap1.wsock,
@@ -504,6 +578,11 @@ class Mux(Handler):
 
 class MuxWrapper(SockWrapper):
 
+    def dispose(self):
+        # Our rsock/wsock are the mux's own stdin/stdout, shared by every
+        # channel; the mux owns them and they must outlive us.
+        pass
+
     def __init__(self, mux, channel):
         SockWrapper.__init__(self, mux.rfile, mux.wfile)
         self.mux = mux
@@ -595,6 +674,7 @@ def runonce(handlers, mux):
     to_remove = [s for s in handlers if not s.ok]
     for h in to_remove:
         handlers.remove(h)
+        h.dispose()
 
     for s in handlers:
         s.pre_select(r, w, x)

--- a/tests/client/test_ssnet.py
+++ b/tests/client/test_ssnet.py
@@ -1,3 +1,4 @@
+import queue
 import socket
 import time
 
@@ -35,6 +36,27 @@ def test_close_later_tolerates_none_and_double_close():
     ssnet.close_later(s)  # already closed; must not raise
     assert _drain()
     other.close()
+
+
+def test_close_later_closes_inline_when_the_backlog_is_full():
+    """A full queue means the closers cannot keep up; holding the fd open
+    would be worse than taking the stall here."""
+    class FullQueue:
+        # raises from put() too, so a regression fails instead of hanging
+        def put_nowait(self, item):
+            raise queue.Full
+
+        put = put_nowait
+
+    a, b = socket.socketpair()
+    saved = ssnet._close_q
+    ssnet._close_q = FullQueue()
+    try:
+        ssnet.close_later(a)
+        assert a.fileno() == -1  # closed inline, not queued
+    finally:
+        ssnet._close_q = saved
+        b.close()
 
 
 def test_handler_dispose_is_a_noop():

--- a/tests/client/test_ssnet.py
+++ b/tests/client/test_ssnet.py
@@ -1,0 +1,80 @@
+import socket
+import time
+
+import sshuttle.ssnet as ssnet
+
+
+def _drain(timeout=5.0):
+    """Wait for the close helpers to work through the queue."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if ssnet._close_q is None or ssnet._close_q.empty():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_close_later_closes_the_socket():
+    a, b = socket.socketpair()
+    try:
+        ssnet.close_later(a)
+        assert _drain()
+        # give the helper a moment to actually run close() after the get()
+        deadline = time.monotonic() + 5.0
+        while a.fileno() != -1 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert a.fileno() == -1
+    finally:
+        b.close()
+
+
+def test_close_later_tolerates_none_and_double_close():
+    ssnet.close_later(None)
+    s, other = socket.socketpair()
+    s.close()
+    ssnet.close_later(s)  # already closed; must not raise
+    assert _drain()
+    other.close()
+
+
+def test_handler_dispose_is_a_noop():
+    ssnet.Handler(socks=[]).dispose()
+
+
+def test_proxy_dispose_leaves_the_mux_alone():
+    """A MuxWrapper's rsock/wsock are the mux's own stdin/stdout, and must
+    never be handed to close_later()."""
+    closed = []
+
+    class FakeSock:
+        def __init__(self, name):
+            self.name = name
+
+        def fileno(self):
+            return -1
+
+        def close(self):
+            closed.append(self.name)
+
+    def wrap(cls, name):
+        # __new__ skips __init__, but these wrappers still run __del__ (and
+        # through it __repr__ and MuxWrapper.nowrite()) when the collector
+        # gets to them, so fill in the attributes those touch.
+        w = cls.__new__(cls)
+        w.rsock = w.wsock = FakeSock(name)
+        w.exc = None
+        w.peername = name
+        w.shut_read = w.shut_write = True
+        w.channel = 0  # MuxWrapper.__repr__ wants one
+        return w
+
+    proxy = ssnet.Proxy.__new__(ssnet.Proxy)
+    proxy.wrap1 = wrap(ssnet.MuxWrapper, 'mux')
+    proxy.wrap2 = wrap(ssnet.SockWrapper, 'real')
+    proxy.dispose()
+    assert _drain()
+
+    deadline = time.monotonic() + 5.0
+    while 'real' not in closed and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert closed == ['real']

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1,9 +1,11 @@
 import io
 import socket
+import time
 
 from unittest.mock import patch, Mock
 
 import sshuttle.server
+import sshuttle.ssnet as ssnet
 
 
 def test__ipmatch():
@@ -58,3 +60,44 @@ default via 192.168.1.1 dev wlan0  proto static
     assert list(routes) == [
         (socket.AF_INET, '192.168.1.0', 24)
     ]
+
+
+def _drain(timeout=5.0):
+    """Wait for ssnet's close helpers to work through the queue."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if ssnet._close_q is None or ssnet._close_q.empty():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_dnsproxy_dispose_closes_every_socket_it_made():
+    """try_send() records a socket in self.peers before send(); a socket
+    whose send() failed never reaches self.socks, but still needs closing."""
+    a, b = socket.socketpair()
+    h = sshuttle.server.DnsProxy.__new__(sshuttle.server.DnsProxy)
+    h.peers = {a: 'nameserver'}
+    h.socks = []  # send() failed, so it never got here
+    h.dispose()
+    assert _drain()
+
+    deadline = time.monotonic() + 5.0
+    while a.fileno() != -1 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert a.fileno() == -1
+    b.close()
+
+
+def test_udpproxy_dispose_closes_its_socket():
+    a, b = socket.socketpair()
+    h = sshuttle.server.UdpProxy.__new__(sshuttle.server.UdpProxy)
+    h.sock = a
+    h.dispose()
+    assert _drain()
+
+    deadline = time.monotonic() + 5.0
+    while a.fileno() != -1 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert a.fileno() == -1
+    b.close()


### PR DESCRIPTION
`close()` on a socket is normally instant, but it can block in the kernel for
many seconds on hosts where a socket-filter network extension inspects flow
teardown. On an affected macOS host (third-party endpoint-security and VPN
clients installed) I measured individual `close()` calls blocking 9-12
seconds, with the process at 0% CPU throughout.

Because sshuttle's event loop is single threaded, one blocking `close()`
stalls **every** connection in the tunnel, not just the one being closed.
Requests that normally took 0.2s intermittently took 5-15s, and unrelated
connections stalled together in bursts because they were all queued behind
the same `close()`.

This was hard to attribute. Sockets are reclaimed by the cyclic garbage
collector, so the close fires at whatever statement happens to trigger a
collection. `sample` showed the main thread 88% in `close` beneath
`gc_collect_main -> sock_finalize`, while Python-level timing variously
blamed `recv()`, `fill()` and `select()` depending on where the collection
landed.

### Fix

Hand finished sockets to a small pool of daemon threads:

- `Proxy` grows a `dispose()` hook, called from `runonce()` when a handler is
  dropped from the poll set, so the handoff happens at a deterministic point
  rather than whenever the collector runs.
- A `MuxWrapper`'s `rsock`/`wsock` are the mux's own stdin/stdout, so they are
  explicitly excluded.
- The socket *object* is queued rather than the fd, which keeps it referenced
  until the helper closes it, so the interpreter cannot close the same fd
  twice.
- Peers still see the connection end promptly: the FIN is sent inline by
  `nowrite()` before `dispose()` runs, and only the fd release is deferred.

### Result

Measured on the affected host with the environment otherwise unchanged, so
`close()` is still slow -- it now blocks a helper thread instead of the event
loop:

| | before | after |
|---|---|---|
| single request | ~40% of requests took 1-13s | 60/60 clean, median 0.203s, worst 0.222s |
| page load, 10 assets | 5-10x slower than running directly on the exit node | 0.90-1.03s vs 0.86-0.98s on the exit node |

`sample` after the change, confirming where the blocking moved to:

```
main-thread        __select   (healthy event loop)
sshuttle-closer-*  close      (absorbing the stall)
```

### Notes

- `CLOSERS = 4` is a fixed constant. The threads only ever sleep in `close()`,
  so the pool size is a drain-rate knob rather than a tuning parameter, but I
  am happy to expose it as an option if you would prefer.
- I could not reproduce a slow `close()` in a short-lived process on the same
  host -- every socket state, age, flow count and Python version I tried
  closed in ~0.3ms. So the socket-filter extension is the best-supported
  explanation for *why* close blocks, not a proven one. What is certain is
  that close *does* block there, and that the single-threaded event loop
  turning one slow close into a tunnel-wide stall is a bug in its own right.
- flake8 clean; 77 tests pass, including 4 new ones covering the close path
  and the MuxWrapper exclusion.
